### PR TITLE
Remove unused rerun-if causing rebuild

### DIFF
--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -31,5 +31,6 @@ fn main() {
     println!("cargo:rustc-link-lib=static=wrapper");
 
     println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=include/wrapper.hxx");
     println!("cargo:rerun-if-changed=cpp/wrapper.cpp");
 }

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -31,6 +31,5 @@ fn main() {
     println!("cargo:rustc-link-lib=static=wrapper");
 
     println!("cargo:rerun-if-changed=src/lib.rs");
-    println!("cargo:rerun-if-changed=cpp/wrapper.hxx");
     println!("cargo:rerun-if-changed=cpp/wrapper.cpp");
 }


### PR DESCRIPTION
Since `wrapper.hxx` does not exist the build script would run on every build. Adding 10 seconds per build even when the crate did not change. 