### PR TITLE
Add IsDone to all Tools and IsNull to all Handles

### DIFF
--- a/crates/opencascade-sys/cpp/wrapper.cpp
+++ b/crates/opencascade-sys/cpp/wrapper.cpp
@@ -1,5 +1,11 @@
 #include <wrapper.hxx>
 
+// Runtime
+
+std::unique_ptr<Message_ProgressRange> Message_ProgressRange_ctor(){
+  return std::unique_ptr<Message_ProgressRange>(new Message_ProgressRange());
+}
+
 // Handle stuff
 
 const HandleStandardType& DynamicType(const HandleGeomSurface& surface) {

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -58,6 +58,9 @@ rust::String type_name(const HandleStandardType& handle);
 
 std::unique_ptr<gp_Pnt> HandleGeomCurve_Value(const HandleGeomCurve& curve, const Standard_Real U);
 
+// Runtime
+std::unique_ptr<Message_ProgressRange> Message_ProgressRange_ctor();
+
 // General Shape Stuff
 std::unique_ptr<TopoDS_Shape> new_shape(const TopoDS_Shape& shape);
 

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -180,6 +180,8 @@ pub mod ffi {
         ) -> UniquePtr<BRepBuilderAPI_MakeEdge>;
         pub fn Vertex1(self: &BRepBuilderAPI_MakeEdge) -> &TopoDS_Vertex;
         pub fn Edge(self: Pin<&mut BRepBuilderAPI_MakeEdge>) -> &TopoDS_Edge;
+        pub fn Build(self: Pin<&mut BRepBuilderAPI_MakeEdge>, progress: &Message_ProgressRange);
+        pub fn IsDone(self: &BRepBuilderAPI_MakeEdge) -> bool;
 
         type BRepBuilderAPI_MakeWire;
         pub fn BRepBuilderAPI_MakeWire_ctor() -> UniquePtr<BRepBuilderAPI_MakeWire>;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -41,6 +41,16 @@ pub mod ffi {
             geom_surface_handle: &HandleGeomSurface,
         ) -> UniquePtr<HandleGeomPlane>;
 
+        pub fn IsNull(self: &HandleStandardType) -> bool;
+        pub fn IsNull(self: &HandleGeomCurve) -> bool;
+        pub fn IsNull(self: &HandleGeomTrimmedCurve) -> bool;
+        pub fn IsNull(self: &HandleGeomSurface) -> bool;
+        pub fn IsNull(self: &HandleGeomPlane) -> bool;
+        pub fn IsNull(self: &HandleGeom2d_Curve) -> bool;
+        pub fn IsNull(self: &HandleGeom2d_Ellipse) -> bool;
+        pub fn IsNull(self: &HandleGeom2d_TrimmedCurve) -> bool;
+        pub fn IsNull(self: &HandleGeom_CylindricalSurface) -> bool;
+
         pub fn HandleGeomCurve_Value(curve: &HandleGeomCurve, u: f64) -> UniquePtr<gp_Pnt>;
 
         // General Shape Stuff

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -19,6 +19,10 @@ pub mod ffi {
         // OCCT Includes
         include!("opencascade-sys/include/wrapper.hxx");
 
+        // Runtime
+        type Message_ProgressRange;
+        pub fn Message_ProgressRange_ctor() -> UniquePtr<Message_ProgressRange>;
+
         // Handles
         type HandleStandardType;
         type HandleGeomCurve;
@@ -190,6 +194,7 @@ pub mod ffi {
         ) -> UniquePtr<BRepBuilderAPI_MakeWire>;
         pub fn Shape(self: Pin<&mut BRepBuilderAPI_MakeWire>) -> &TopoDS_Shape;
         pub fn Wire(self: Pin<&mut BRepBuilderAPI_MakeWire>) -> &TopoDS_Wire;
+        pub fn Build(self: Pin<&mut BRepBuilderAPI_MakeWire>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepBuilderAPI_MakeWire) -> bool;
 
         type BRepBuilderAPI_MakeFace;
@@ -198,6 +203,7 @@ pub mod ffi {
             only_plane: bool,
         ) -> UniquePtr<BRepBuilderAPI_MakeFace>;
         pub fn Shape(self: Pin<&mut BRepBuilderAPI_MakeFace>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepBuilderAPI_MakeFace>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepBuilderAPI_MakeFace) -> bool;
 
         // Primitives
@@ -209,6 +215,7 @@ pub mod ffi {
             canonize: bool,
         ) -> UniquePtr<BRepPrimAPI_MakePrism>;
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakePrism>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepPrimAPI_MakePrism>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakePrism) -> bool;
 
         type BRepPrimAPI_MakeRevol;
@@ -219,6 +226,7 @@ pub mod ffi {
             copy: bool,
         ) -> UniquePtr<BRepPrimAPI_MakeRevol>;
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeRevol>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepPrimAPI_MakeRevol>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakeRevol) -> bool;
 
         #[rust_name = "add_edge"]
@@ -234,6 +242,7 @@ pub mod ffi {
             height: f64,
         ) -> UniquePtr<BRepPrimAPI_MakeCylinder>;
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeCylinder>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepPrimAPI_MakeCylinder>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakeCylinder) -> bool;
 
         type BRepPrimAPI_MakeBox;
@@ -244,11 +253,13 @@ pub mod ffi {
             dz: f64,
         ) -> UniquePtr<BRepPrimAPI_MakeBox>;
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeBox>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepPrimAPI_MakeBox>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakeBox) -> bool;
 
         type BRepPrimAPI_MakeSphere;
         pub fn BRepPrimAPI_MakeSphere_ctor(r: f64) -> UniquePtr<BRepPrimAPI_MakeSphere>;
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeSphere>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepPrimAPI_MakeSphere>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakeSphere) -> bool;
 
         // BRepLib
@@ -262,6 +273,7 @@ pub mod ffi {
         #[rust_name = "add_edge"]
         pub fn Add(self: Pin<&mut BRepFilletAPI_MakeFillet>, radius: f64, edge: &TopoDS_Edge);
         pub fn Shape(self: Pin<&mut BRepFilletAPI_MakeFillet>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepFilletAPI_MakeFillet>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepFilletAPI_MakeFillet) -> bool;
 
         // Chamfers
@@ -272,6 +284,7 @@ pub mod ffi {
         #[rust_name = "add_edge"]
         pub fn Add(self: Pin<&mut BRepFilletAPI_MakeChamfer>, distance: f64, edge: &TopoDS_Edge);
         pub fn Shape(self: Pin<&mut BRepFilletAPI_MakeChamfer>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepFilletAPI_MakeChamfer>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepFilletAPI_MakeChamfer) -> bool;
 
         // Solids
@@ -285,6 +298,10 @@ pub mod ffi {
             tolerance: f64,
         );
         pub fn Shape(self: Pin<&mut BRepOffsetAPI_MakeThickSolid>) -> &TopoDS_Shape;
+        pub fn Build(
+            self: Pin<&mut BRepOffsetAPI_MakeThickSolid>,
+            progress: &Message_ProgressRange,
+        );
         pub fn IsDone(self: &BRepOffsetAPI_MakeThickSolid) -> bool;
 
         // Lofting
@@ -295,6 +312,7 @@ pub mod ffi {
         pub fn AddWire(self: Pin<&mut BRepOffsetAPI_ThruSections>, wire: &TopoDS_Wire);
         pub fn CheckCompatibility(self: Pin<&mut BRepOffsetAPI_ThruSections>, check: bool);
         pub fn Shape(self: Pin<&mut BRepOffsetAPI_ThruSections>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepOffsetAPI_ThruSections>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepOffsetAPI_ThruSections) -> bool;
 
         // Boolean Operations
@@ -304,6 +322,7 @@ pub mod ffi {
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Fuse>;
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Fuse>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepAlgoAPI_Fuse>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Fuse) -> bool;
 
         type BRepAlgoAPI_Cut;
@@ -312,6 +331,7 @@ pub mod ffi {
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Cut>;
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Cut>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepAlgoAPI_Cut>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Cut) -> bool;
 
         type BRepAlgoAPI_Common;
@@ -320,6 +340,7 @@ pub mod ffi {
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Common>;
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Common>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepAlgoAPI_Common>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Common) -> bool;
 
         type BRepAlgoAPI_Section;
@@ -328,6 +349,7 @@ pub mod ffi {
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Section>;
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Section>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepAlgoAPI_Section>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Section) -> bool;
 
         // Geometric processor
@@ -364,6 +386,7 @@ pub mod ffi {
             copy: bool,
         ) -> UniquePtr<BRepBuilderAPI_Transform>;
         pub fn Shape(self: Pin<&mut BRepBuilderAPI_Transform>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepBuilderAPI_Transform>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepBuilderAPI_Transform) -> bool;
 
         // Topology Explorer

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -224,6 +224,7 @@ pub mod ffi {
             height: f64,
         ) -> UniquePtr<BRepPrimAPI_MakeCylinder>;
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeCylinder>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepPrimAPI_MakeCylinder) -> bool;
 
         type BRepPrimAPI_MakeBox;
         pub fn BRepPrimAPI_MakeBox_ctor(
@@ -233,10 +234,12 @@ pub mod ffi {
             dz: f64,
         ) -> UniquePtr<BRepPrimAPI_MakeBox>;
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeBox>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepPrimAPI_MakeBox) -> bool;
 
         type BRepPrimAPI_MakeSphere;
         pub fn BRepPrimAPI_MakeSphere_ctor(r: f64) -> UniquePtr<BRepPrimAPI_MakeSphere>;
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeSphere>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepPrimAPI_MakeSphere) -> bool;
 
         // BRepLib
         pub fn BRepLibBuildCurves3d(shape: &TopoDS_Shape) -> bool;
@@ -249,6 +252,7 @@ pub mod ffi {
         #[rust_name = "add_edge"]
         pub fn Add(self: Pin<&mut BRepFilletAPI_MakeFillet>, radius: f64, edge: &TopoDS_Edge);
         pub fn Shape(self: Pin<&mut BRepFilletAPI_MakeFillet>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepFilletAPI_MakeFillet) -> bool;
 
         // Chamfers
         type BRepFilletAPI_MakeChamfer;
@@ -258,6 +262,7 @@ pub mod ffi {
         #[rust_name = "add_edge"]
         pub fn Add(self: Pin<&mut BRepFilletAPI_MakeChamfer>, distance: f64, edge: &TopoDS_Edge);
         pub fn Shape(self: Pin<&mut BRepFilletAPI_MakeChamfer>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepFilletAPI_MakeChamfer) -> bool;
 
         // Solids
         type BRepOffsetAPI_MakeThickSolid;
@@ -270,6 +275,7 @@ pub mod ffi {
             tolerance: f64,
         );
         pub fn Shape(self: Pin<&mut BRepOffsetAPI_MakeThickSolid>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepOffsetAPI_MakeThickSolid) -> bool;
 
         // Lofting
         type BRepOffsetAPI_ThruSections;
@@ -279,6 +285,7 @@ pub mod ffi {
         pub fn AddWire(self: Pin<&mut BRepOffsetAPI_ThruSections>, wire: &TopoDS_Wire);
         pub fn CheckCompatibility(self: Pin<&mut BRepOffsetAPI_ThruSections>, check: bool);
         pub fn Shape(self: Pin<&mut BRepOffsetAPI_ThruSections>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepOffsetAPI_ThruSections) -> bool;
 
         // Boolean Operations
         type BRepAlgoAPI_Fuse;
@@ -287,6 +294,7 @@ pub mod ffi {
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Fuse>;
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Fuse>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepAlgoAPI_Fuse) -> bool;
 
         type BRepAlgoAPI_Cut;
         pub fn BRepAlgoAPI_Cut_ctor(
@@ -294,6 +302,7 @@ pub mod ffi {
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Cut>;
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Cut>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepAlgoAPI_Cut) -> bool;
 
         type BRepAlgoAPI_Common;
         pub fn BRepAlgoAPI_Common_ctor(
@@ -301,6 +310,7 @@ pub mod ffi {
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Common>;
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Common>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepAlgoAPI_Common) -> bool;
 
         type BRepAlgoAPI_Section;
         pub fn BRepAlgoAPI_Section_ctor(
@@ -308,6 +318,7 @@ pub mod ffi {
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Section>;
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Section>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepAlgoAPI_Section) -> bool;
 
         // Geometric processor
         type gp_Ax1;
@@ -343,6 +354,7 @@ pub mod ffi {
             copy: bool,
         ) -> UniquePtr<BRepBuilderAPI_Transform>;
         pub fn Shape(self: Pin<&mut BRepBuilderAPI_Transform>) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepBuilderAPI_Transform) -> bool;
 
         // Topology Explorer
         type TopExp_Explorer;
@@ -381,5 +393,6 @@ pub mod ffi {
             deflection: f64,
         ) -> UniquePtr<BRepMesh_IncrementalMesh>;
         pub fn Shape(self: &BRepMesh_IncrementalMesh) -> &TopoDS_Shape;
+        pub fn IsDone(self: &BRepMesh_IncrementalMesh) -> bool;
     }
 }


### PR DESCRIPTION
Add IsDone to all Tools and IsNull to all Handles.

Tools that do not check for IsDone will throw.
Handles that do not check IsNull may segfault. 
These are needed to wrap those operations safely. 
