### PR TITLE
Add support to retrieve 3D triangle data without writing to STL

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -330,28 +330,32 @@ BRepBuilderAPI_Transform_ctor(const TopoDS_Shape &shape, const gp_Trsf &transfor
 }
 
 // Topology Explorer
-inline std::unique_ptr<TopExp_Explorer> TopExp_Explorer_ctor(const TopoDS_Shape& shape, const TopAbs_ShapeEnum to_find) {
-    return std::unique_ptr<TopExp_Explorer>(new TopExp_Explorer(shape, to_find));
+inline std::unique_ptr<TopExp_Explorer> TopExp_Explorer_ctor(const TopoDS_Shape &shape,
+                                                             const TopAbs_ShapeEnum to_find) {
+  return std::unique_ptr<TopExp_Explorer>(new TopExp_Explorer(shape, to_find));
 }
 
-inline std::unique_ptr<HandleGeomSurface> BRep_Tool_Surface(const TopoDS_Face& face) {
-    return std::unique_ptr<HandleGeomSurface>(new opencascade::handle<Geom_Surface>(BRep_Tool::Surface(face)));
+inline std::unique_ptr<HandleGeomSurface> BRep_Tool_Surface(const TopoDS_Face &face) {
+  return std::unique_ptr<HandleGeomSurface>(new opencascade::handle<Geom_Surface>(BRep_Tool::Surface(face)));
 }
 
-inline std::unique_ptr<HandleGeomCurve> BRep_Tool_Curve(const TopoDS_Edge& edge, Standard_Real& first, Standard_Real& last) {
-    return std::unique_ptr<HandleGeomCurve>(new opencascade::handle<Geom_Curve>(BRep_Tool::Curve(edge, first, last)));
+inline std::unique_ptr<HandleGeomCurve> BRep_Tool_Curve(const TopoDS_Edge &edge, Standard_Real &first,
+                                                        Standard_Real &last) {
+  return std::unique_ptr<HandleGeomCurve>(new opencascade::handle<Geom_Curve>(BRep_Tool::Curve(edge, first, last)));
 }
 
-inline std::unique_ptr<gp_Pnt> BRep_Tool_Pnt(const TopoDS_Vertex& vertex) {
-    return std::unique_ptr<gp_Pnt>(new gp_Pnt(BRep_Tool::Pnt(vertex)));
+inline std::unique_ptr<gp_Pnt> BRep_Tool_Pnt(const TopoDS_Vertex &vertex) {
+  return std::unique_ptr<gp_Pnt>(new gp_Pnt(BRep_Tool::Pnt(vertex)));
 }
 
-inline std::unique_ptr<Handle_Poly_Triangulation> BRep_Tool_Triangulation(const TopoDS_Face& face, TopLoc_Location& location) {
-    return std::unique_ptr<Handle_Poly_Triangulation>(new opencascade::handle<Poly_Triangulation>(BRep_Tool::Triangulation(face, location)));
+inline std::unique_ptr<Handle_Poly_Triangulation> BRep_Tool_Triangulation(const TopoDS_Face &face,
+                                                                          TopLoc_Location &location) {
+  return std::unique_ptr<Handle_Poly_Triangulation>(
+      new opencascade::handle<Poly_Triangulation>(BRep_Tool::Triangulation(face, location)));
 }
 
-inline std::unique_ptr<TopoDS_Shape> ExplorerCurrentShape(const TopExp_Explorer& explorer) {
-    return std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape(explorer.Current()));
+inline std::unique_ptr<TopoDS_Shape> ExplorerCurrentShape(const TopExp_Explorer &explorer) {
+  return std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape(explorer.Current()));
 }
 
 // Data export
@@ -364,18 +368,21 @@ inline bool write_stl(StlAPI_Writer &writer, const TopoDS_Shape &theShape, rust:
 }
 
 // Triangulation
-inline std::unique_ptr<TopLoc_Location> TopLoc_Location_ctor(){
-    return std::unique_ptr<TopLoc_Location>(new TopLoc_Location());
+inline std::unique_ptr<TopLoc_Location> TopLoc_Location_ctor() {
+  return std::unique_ptr<TopLoc_Location>(new TopLoc_Location());
 }
 
-inline std::unique_ptr<BRepMesh_IncrementalMesh> BRepMesh_IncrementalMesh_ctor(const TopoDS_Shape& shape, double deflection) {
-    return std::unique_ptr<BRepMesh_IncrementalMesh>(new BRepMesh_IncrementalMesh(shape, deflection));
+inline std::unique_ptr<BRepMesh_IncrementalMesh> BRepMesh_IncrementalMesh_ctor(const TopoDS_Shape &shape,
+                                                                               double deflection) {
+  return std::unique_ptr<BRepMesh_IncrementalMesh>(new BRepMesh_IncrementalMesh(shape, deflection));
 }
 
-inline std::unique_ptr<gp_Dir> Poly_Triangulation_Normal(const Poly_Triangulation& triangulation, const Standard_Integer index) {
-    return std::unique_ptr<gp_Dir>(new gp_Dir(triangulation.Normal(index)));
+inline std::unique_ptr<gp_Dir> Poly_Triangulation_Normal(const Poly_Triangulation &triangulation,
+                                                         const Standard_Integer index) {
+  return std::unique_ptr<gp_Dir>(new gp_Dir(triangulation.Normal(index)));
 }
 
-inline std::unique_ptr<gp_Pnt> Poly_Triangulation_Node(const Poly_Triangulation& triangulation, const Standard_Integer index) {
-    return std::unique_ptr<gp_Pnt>(new gp_Pnt(triangulation.Node(index)));
+inline std::unique_ptr<gp_Pnt> Poly_Triangulation_Node(const Poly_Triangulation &triangulation,
+                                                       const Standard_Integer index) {
+  return std::unique_ptr<gp_Pnt>(new gp_Pnt(triangulation.Node(index)));
 }

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -60,6 +60,13 @@ typedef opencascade::handle<Geom_CylindricalSurface> HandleGeom_CylindricalSurfa
 typedef opencascade::handle<Poly_Triangulation> Handle_Poly_Triangulation;
 
 // Handle stuff
+template <typename T> const T &handle_try_deref(const opencascade::handle<T> &handle) {
+  if (handle.IsNull()) {
+    throw std::runtime_error("null handle dereference");
+  }
+  return *handle;
+}
+
 inline const HandleStandardType &DynamicType(const HandleGeomSurface &surface) { return surface->DynamicType(); }
 
 inline rust::String type_name(const HandleStandardType &handle) { return std::string(handle->Name()); }
@@ -188,4 +195,14 @@ inline std::unique_ptr<TopoDS_Shape> ExplorerCurrentShape(const TopExp_Explorer 
 // Data export
 inline bool write_stl(StlAPI_Writer &writer, const TopoDS_Shape &theShape, rust::String theFileName) {
   return writer.Write(theShape, theFileName.c_str());
+}
+
+inline std::unique_ptr<gp_Dir> Poly_Triangulation_Normal(const Poly_Triangulation &triangulation,
+                                                         const Standard_Integer index) {
+  return std::unique_ptr<gp_Dir>(new gp_Dir(triangulation.Normal(index)));
+}
+
+inline std::unique_ptr<gp_Pnt> Poly_Triangulation_Node(const Poly_Triangulation &triangulation,
+                                                       const Standard_Integer index) {
+  return std::unique_ptr<gp_Pnt>(new gp_Pnt(triangulation.Node(index)));
 }

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -52,6 +52,7 @@ typedef opencascade::handle<Geom2d_Curve> HandleGeom2d_Curve;
 typedef opencascade::handle<Geom2d_Ellipse> HandleGeom2d_Ellipse;
 typedef opencascade::handle<Geom2d_TrimmedCurve> HandleGeom2d_TrimmedCurve;
 typedef opencascade::handle<Geom_CylindricalSurface> HandleGeom_CylindricalSurface;
+typedef opencascade::handle<Poly_Triangulation> Handle_Poly_Triangulation;
 
 // Runtime
 inline std::unique_ptr<Message_ProgressRange> Message_ProgressRange_ctor() {
@@ -329,26 +330,28 @@ BRepBuilderAPI_Transform_ctor(const TopoDS_Shape &shape, const gp_Trsf &transfor
 }
 
 // Topology Explorer
-inline std::unique_ptr<TopExp_Explorer> TopExp_Explorer_ctor(const TopoDS_Shape &shape,
-                                                             const TopAbs_ShapeEnum to_find) {
-  return std::unique_ptr<TopExp_Explorer>(new TopExp_Explorer(shape, to_find));
+inline std::unique_ptr<TopExp_Explorer> TopExp_Explorer_ctor(const TopoDS_Shape& shape, const TopAbs_ShapeEnum to_find) {
+    return std::unique_ptr<TopExp_Explorer>(new TopExp_Explorer(shape, to_find));
 }
 
-inline std::unique_ptr<HandleGeomSurface> BRep_Tool_Surface(const TopoDS_Face &face) {
-  return std::unique_ptr<HandleGeomSurface>(new opencascade::handle<Geom_Surface>(BRep_Tool::Surface(face)));
+inline std::unique_ptr<HandleGeomSurface> BRep_Tool_Surface(const TopoDS_Face& face) {
+    return std::unique_ptr<HandleGeomSurface>(new opencascade::handle<Geom_Surface>(BRep_Tool::Surface(face)));
 }
 
-inline std::unique_ptr<HandleGeomCurve> BRep_Tool_Curve(const TopoDS_Edge &edge, Standard_Real &first,
-                                                        Standard_Real &last) {
-  return std::unique_ptr<HandleGeomCurve>(new opencascade::handle<Geom_Curve>(BRep_Tool::Curve(edge, first, last)));
+inline std::unique_ptr<HandleGeomCurve> BRep_Tool_Curve(const TopoDS_Edge& edge, Standard_Real& first, Standard_Real& last) {
+    return std::unique_ptr<HandleGeomCurve>(new opencascade::handle<Geom_Curve>(BRep_Tool::Curve(edge, first, last)));
 }
 
-inline std::unique_ptr<gp_Pnt> BRep_Tool_Pnt(const TopoDS_Vertex &vertex) {
-  return std::unique_ptr<gp_Pnt>(new gp_Pnt(BRep_Tool::Pnt(vertex)));
+inline std::unique_ptr<gp_Pnt> BRep_Tool_Pnt(const TopoDS_Vertex& vertex) {
+    return std::unique_ptr<gp_Pnt>(new gp_Pnt(BRep_Tool::Pnt(vertex)));
 }
 
-inline std::unique_ptr<TopoDS_Shape> ExplorerCurrentShape(const TopExp_Explorer &explorer) {
-  return std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape(explorer.Current()));
+inline std::unique_ptr<Handle_Poly_Triangulation> BRep_Tool_Triangulation(const TopoDS_Face& face, TopLoc_Location& location) {
+    return std::unique_ptr<Handle_Poly_Triangulation>(new opencascade::handle<Poly_Triangulation>(BRep_Tool::Triangulation(face, location)));
+}
+
+inline std::unique_ptr<TopoDS_Shape> ExplorerCurrentShape(const TopExp_Explorer& explorer) {
+    return std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape(explorer.Current()));
 }
 
 // Data export
@@ -361,7 +364,18 @@ inline bool write_stl(StlAPI_Writer &writer, const TopoDS_Shape &theShape, rust:
 }
 
 // Triangulation
-inline std::unique_ptr<BRepMesh_IncrementalMesh> BRepMesh_IncrementalMesh_ctor(const TopoDS_Shape &shape,
-                                                                               double deflection) {
-  return std::unique_ptr<BRepMesh_IncrementalMesh>(new BRepMesh_IncrementalMesh(shape, deflection));
+inline std::unique_ptr<TopLoc_Location> TopLoc_Location_ctor(){
+    return std::unique_ptr<TopLoc_Location>(new TopLoc_Location());
+}
+
+inline std::unique_ptr<BRepMesh_IncrementalMesh> BRepMesh_IncrementalMesh_ctor(const TopoDS_Shape& shape, double deflection) {
+    return std::unique_ptr<BRepMesh_IncrementalMesh>(new BRepMesh_IncrementalMesh(shape, deflection));
+}
+
+inline std::unique_ptr<gp_Dir> Poly_Triangulation_Normal(const Poly_Triangulation& triangulation, const Standard_Integer index) {
+    return std::unique_ptr<gp_Dir>(new gp_Dir(triangulation.Normal(index)));
+}
+
+inline std::unique_ptr<gp_Pnt> Poly_Triangulation_Node(const Poly_Triangulation& triangulation, const Standard_Integer index) {
+    return std::unique_ptr<gp_Pnt>(new gp_Pnt(triangulation.Node(index)));
 }

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -458,7 +458,7 @@ pub mod ffi {
         /// # Safety
         /// Since this handle may be null, this is only safe if IsNull has been checked.
         /// The handle must also outlive the reference returned.
-        pub unsafe fn get(self: &Handle_Poly_Triangulation) -> *mut Poly_Triangulation;
+        pub fn get(self: &Handle_Poly_Triangulation) -> *mut Poly_Triangulation;
 
         type Poly_Triangulation;
         pub fn NbNodes(self: &Poly_Triangulation) -> i32;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -455,9 +455,6 @@ pub mod ffi {
 
         type Handle_Poly_Triangulation;
         pub fn IsNull(self: &Handle_Poly_Triangulation) -> bool;
-        /// # Safety
-        /// Since this handle may be null, this is only safe if IsNull has been checked.
-        /// The handle must also outlive the reference returned.
         pub fn get(self: &Handle_Poly_Triangulation) -> *mut Poly_Triangulation;
 
         type Poly_Triangulation;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -556,11 +556,15 @@ pub mod ffi {
         pub fn IsDone(self: &BRepMesh_IncrementalMesh) -> bool;
 
         type TopLoc_Location;
+        #[cxx_name = "construct_unique"]
         pub fn TopLoc_Location_ctor() -> UniquePtr<TopLoc_Location>;
 
         type Handle_Poly_Triangulation;
         pub fn IsNull(self: &Handle_Poly_Triangulation) -> bool;
-        pub fn get(self: &Handle_Poly_Triangulation) -> *mut Poly_Triangulation;
+        #[cxx_name = "handle_try_deref"]
+        pub fn Handle_Poly_Triangulation_Get(
+            handle: &Handle_Poly_Triangulation,
+        ) -> Result<&Poly_Triangulation>;
 
         type Poly_Triangulation;
         pub fn NbNodes(self: &Poly_Triangulation) -> i32;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -13,6 +13,14 @@ pub mod ffi {
         TopAbs_SHAPE,
     }
 
+    #[repr(u32)]
+    pub enum TopAbs_Orientation {
+        TopAbs_FORWARD,
+        TopAbs_REVERSED,
+        TopAbs_INTERNAL,
+        TopAbs_EXTERNAL,
+    }
+
     unsafe extern "C++" {
         // https://github.com/dtolnay/cxx/issues/280
 
@@ -153,6 +161,10 @@ pub mod ffi {
 
         pub fn IsNull(self: &TopoDS_Shape) -> bool;
         pub fn IsEqual(self: &TopoDS_Shape, other: &TopoDS_Shape) -> bool;
+
+        type TopAbs_Orientation;
+        pub fn Orientation(self: &TopoDS_Shape) -> TopAbs_Orientation;
+        pub fn Orientation(self: &TopoDS_Face) -> TopAbs_Orientation;
 
         // Compound Shapes
         type TopoDS_Compound;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -443,6 +443,9 @@ pub mod ffi {
 
         type Handle_Poly_Triangulation;
         pub fn IsNull(self: &Handle_Poly_Triangulation) -> bool;
+        /// # Safety
+        /// Since this handle may be null, this is only safe if IsNull has been checked.
+        /// The handle must also outlive the reference returned.
         pub unsafe fn get(self: &Handle_Poly_Triangulation) -> *mut Poly_Triangulation;
 
         type Poly_Triangulation;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -366,6 +366,10 @@ pub mod ffi {
         pub fn gp_OZ() -> &'static gp_Ax1;
         pub fn gp_DZ() -> &'static gp_Dir;
 
+        pub fn X(self: &gp_Dir) -> f64;
+        pub fn Y(self: &gp_Dir) -> f64;
+        pub fn Z(self: &gp_Dir) -> f64;
+
         pub fn gp_Ax2_ctor(origin: &gp_Pnt, main_dir: &gp_Dir) -> UniquePtr<gp_Ax2>;
         pub fn gp_Ax3_from_gp_Ax2(axis: &gp_Ax2) -> UniquePtr<gp_Ax3>;
         pub fn gp_Dir2d_ctor(x: f64, y: f64) -> UniquePtr<gp_Dir2d>;
@@ -410,6 +414,10 @@ pub mod ffi {
             last: &mut f64,
         ) -> UniquePtr<HandleGeomCurve>;
         pub fn BRep_Tool_Pnt(vertex: &TopoDS_Vertex) -> UniquePtr<gp_Pnt>;
+        pub fn BRep_Tool_Triangulation(
+            face: &TopoDS_Face,
+            location: Pin<&mut TopLoc_Location>,
+        ) -> UniquePtr<Handle_Poly_Triangulation>;
 
         // Data export
         type StlAPI_Writer;
@@ -429,5 +437,29 @@ pub mod ffi {
         ) -> UniquePtr<BRepMesh_IncrementalMesh>;
         pub fn Shape(self: &BRepMesh_IncrementalMesh) -> &TopoDS_Shape;
         pub fn IsDone(self: &BRepMesh_IncrementalMesh) -> bool;
+
+        type TopLoc_Location;
+        pub fn TopLoc_Location_ctor() -> UniquePtr<TopLoc_Location>;
+
+        type Handle_Poly_Triangulation;
+        pub fn IsNull(self: &Handle_Poly_Triangulation) -> bool;
+        pub unsafe fn get(self: &Handle_Poly_Triangulation) -> *mut Poly_Triangulation;
+
+        type Poly_Triangulation;
+        pub fn NbNodes(self: &Poly_Triangulation) -> i32;
+        pub fn NbTriangles(self: &Poly_Triangulation) -> i32;
+        pub fn HasNormals(self: &Poly_Triangulation) -> bool;
+        pub fn Triangle(self: &Poly_Triangulation, index: i32) -> &Poly_Triangle;
+        pub fn Poly_Triangulation_Normal(
+            triangulation: &Poly_Triangulation,
+            index: i32,
+        ) -> UniquePtr<gp_Dir>;
+        pub fn Poly_Triangulation_Node(
+            triangulation: &Poly_Triangulation,
+            index: i32,
+        ) -> UniquePtr<gp_Pnt>;
+
+        type Poly_Triangle;
+        pub fn Value(self: &Poly_Triangle, index: i32) -> i32;
     }
 }

--- a/crates/opencascade-sys/tests/triangulation.rs
+++ b/crates/opencascade-sys/tests/triangulation.rs
@@ -28,7 +28,7 @@ fn it_can_access_mesh_triangulation() {
 
                 for corner_index in 1..=3 {
                     let _point =
-                        Poly_Triangulation_Node(&triangulation, triangle.Value(corner_index));
+                        Poly_Triangulation_Node(triangulation, triangle.Value(corner_index));
                     triangle_corners += 1;
                 }
             }

--- a/crates/opencascade-sys/tests/triangulation.rs
+++ b/crates/opencascade-sys/tests/triangulation.rs
@@ -1,0 +1,44 @@
+use opencascade_sys::ffi::{
+    new_point, BRepMesh_IncrementalMesh_ctor, BRepPrimAPI_MakeBox_ctor, BRep_Tool_Triangulation,
+    Poly_Triangulation_Node, TopAbs_ShapeEnum, TopExp_Explorer_ctor, TopLoc_Location_ctor,
+    TopoDS_cast_to_face,
+};
+
+#[test]
+fn it_can_access_mesh_triangulation() {
+    let origin = new_point(0., 0., 0.);
+    let mut cube = BRepPrimAPI_MakeBox_ctor(&origin, 10., 10., 10.);
+
+    let mut mesh = BRepMesh_IncrementalMesh_ctor(cube.pin_mut().Shape(), 0.01);
+
+    let mut triangle_corners = 0;
+
+    let mut edge_explorer =
+        TopExp_Explorer_ctor(mesh.pin_mut().Shape(), TopAbs_ShapeEnum::TopAbs_FACE);
+    while edge_explorer.More() {
+        let face = TopoDS_cast_to_face(edge_explorer.Current());
+        let mut location = TopLoc_Location_ctor();
+
+        let triangulation_handle = BRep_Tool_Triangulation(&face, location.pin_mut());
+        if !triangulation_handle.IsNull() {
+            let triangulation = unsafe { &*triangulation_handle.get() };
+
+            for index in 0..triangulation.NbTriangles() {
+                let triangle = triangulation.Triangle(index + 1);
+
+                for corner_index in 1..=3 {
+                    let _point =
+                        Poly_Triangulation_Node(&triangulation, triangle.Value(corner_index));
+                    triangle_corners += 1;
+                }
+            }
+        }
+
+        edge_explorer.pin_mut().Next();
+    }
+
+    const SIDES: i32 = 6;
+    const TRI_PER_SIDE: i32 = 2;
+    const CORNER_PER_TRI: i32 = 3;
+    assert_eq!(SIDES * TRI_PER_SIDE * CORNER_PER_TRI, triangle_corners)
+}

--- a/crates/opencascade-sys/tests/triangulation.rs
+++ b/crates/opencascade-sys/tests/triangulation.rs
@@ -19,7 +19,7 @@ fn it_can_access_mesh_triangulation() {
         let face = TopoDS_cast_to_face(edge_explorer.Current());
         let mut location = TopLoc_Location_ctor();
 
-        let triangulation_handle = BRep_Tool_Triangulation(&face, location.pin_mut());
+        let triangulation_handle = BRep_Tool_Triangulation(face, location.pin_mut());
         if let Ok(triangulation) = Handle_Poly_Triangulation_Get(&triangulation_handle) {
             for index in 0..triangulation.NbTriangles() {
                 let triangle = triangulation.Triangle(index + 1);

--- a/crates/opencascade-sys/tests/triangulation.rs
+++ b/crates/opencascade-sys/tests/triangulation.rs
@@ -1,7 +1,7 @@
 use opencascade_sys::ffi::{
     new_point, BRepMesh_IncrementalMesh_ctor, BRepPrimAPI_MakeBox_ctor, BRep_Tool_Triangulation,
-    Poly_Triangulation_Node, TopAbs_ShapeEnum, TopExp_Explorer_ctor, TopLoc_Location_ctor,
-    TopoDS_cast_to_face,
+    Handle_Poly_Triangulation_Get, Poly_Triangulation_Node, TopAbs_ShapeEnum, TopExp_Explorer_ctor,
+    TopLoc_Location_ctor, TopoDS_cast_to_face,
 };
 
 #[test]
@@ -20,9 +20,7 @@ fn it_can_access_mesh_triangulation() {
         let mut location = TopLoc_Location_ctor();
 
         let triangulation_handle = BRep_Tool_Triangulation(&face, location.pin_mut());
-        if !triangulation_handle.IsNull() {
-            let triangulation = unsafe { &*triangulation_handle.get() };
-
+        if let Ok(triangulation) = Handle_Poly_Triangulation_Get(&triangulation_handle) {
             for index in 0..triangulation.NbTriangles() {
                 let triangle = triangulation.Triangle(index + 1);
 


### PR DESCRIPTION
Adding the necessary parts to access mesh 3D triangle data. Supports triangles, nodes and normals. 

I also added a test case to the project. This was mainly to ensure that what I was adding was going to work. I think it cant hurt to leave in but feel free to let me know if you prefer I didn't include it. 

Note: I tried a different way of dealing with handles. Using the `get` property and making an unsafe case to a pointer. This should be an easier pattern since it doesn't need so much custom implementation within the wrapper. 