### PR TITLE
Unify the explorer interface using XXX_to_owned

### DIFF
--- a/crates/opencascade-sys/examples/bottle.rs
+++ b/crates/opencascade-sys/examples/bottle.rs
@@ -114,7 +114,7 @@ pub fn main() {
         let shape = ExplorerCurrentShape(&face_explorer);
         let face = TopoDS_cast_to_face(&shape);
 
-        let surface = BRep_Tool_Surface(&face);
+        let surface = BRep_Tool_Surface(face);
         let dynamic_type = DynamicType(&surface);
         let name = type_name(dynamic_type);
 

--- a/crates/opencascade-sys/examples/bottle.rs
+++ b/crates/opencascade-sys/examples/bottle.rs
@@ -16,8 +16,8 @@ use opencascade_sys::ffi::{
     GC_MakeSegment_Value, GC_MakeSegment_point_point, Geom2d_Ellipse_ctor,
     Geom2d_TrimmedCurve_ctor, Geom_CylindricalSurface_ctor, HandleGeom2d_TrimmedCurve_to_curve,
     MakeThickSolidByJoin, StlAPI_Writer_ctor, TopAbs_ShapeEnum, TopExp_Explorer_ctor,
-    TopoDS_Compound_as_shape, TopoDS_Compound_ctor, TopoDS_Face, TopoDS_cast_to_edge,
-    TopoDS_cast_to_face, TopoDS_cast_to_wire,
+    TopoDS_Compound_as_shape, TopoDS_Compound_ctor, TopoDS_Face, TopoDS_Face_to_owned,
+    TopoDS_cast_to_edge, TopoDS_cast_to_face, TopoDS_cast_to_wire,
 };
 
 // All dimensions are in millimeters.
@@ -125,7 +125,7 @@ pub fn main() {
             let plane_z = plane_location.Z();
             if plane_z > z_max {
                 z_max = plane_z;
-                top_face = Some(face);
+                top_face = Some(TopoDS_Face_to_owned(face));
             }
         }
 

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -78,11 +78,6 @@ inline std::unique_ptr<HandleGeomPlane> new_HandleGeomPlane_from_HandleGeomSurfa
   return std::unique_ptr<HandleGeomPlane>(new opencascade::handle<Geom_Plane>(plane_handle));
 }
 
-// General Shape Stuff
-inline std::unique_ptr<TopoDS_Shape> new_shape(const TopoDS_Shape &shape) {
-  return std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape(shape));
-}
-
 // Collections
 inline std::unique_ptr<TopTools_ListOfShape> new_list_of_shape() {
   return std::unique_ptr<TopTools_ListOfShape>(new TopTools_ListOfShape());
@@ -303,8 +298,26 @@ inline const TopoDS_Wire &TopoDS_cast_to_wire(const TopoDS_Shape &shape) { retur
 
 inline const TopoDS_Edge &TopoDS_cast_to_edge(const TopoDS_Shape &shape) { return TopoDS::Edge(shape); }
 
-inline std::unique_ptr<TopoDS_Face> TopoDS_cast_to_face(const TopoDS_Shape &shape) {
-  return std::unique_ptr<TopoDS_Face>(new TopoDS_Face(TopoDS::Face(shape)));
+inline const TopoDS_Face &TopoDS_cast_to_face(const TopoDS_Shape &shape) { return TopoDS::Face(shape); }
+
+inline std::unique_ptr<TopoDS_Shape> TopoDS_Shape_to_owned(const TopoDS_Shape &shape) {
+  return std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape(shape));
+}
+
+inline std::unique_ptr<TopoDS_Vertex> TopoDS_Vertex_to_owned(const TopoDS_Vertex &vertex) {
+  return std::unique_ptr<TopoDS_Vertex>(new TopoDS_Vertex(vertex));
+}
+
+inline std::unique_ptr<TopoDS_Wire> TopoDS_Wire_to_owned(const TopoDS_Wire &wire) {
+  return std::unique_ptr<TopoDS_Wire>(new TopoDS_Wire(wire));
+}
+
+inline std::unique_ptr<TopoDS_Edge> TopoDS_Edge_to_owned(const TopoDS_Edge &edge) {
+  return std::unique_ptr<TopoDS_Edge>(new TopoDS_Edge(edge));
+}
+
+inline std::unique_ptr<TopoDS_Face> TopoDS_Face_to_owned(const TopoDS_Face &face) {
+  return std::unique_ptr<TopoDS_Face>(new TopoDS_Face(face));
 }
 
 // Compound shapes

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -57,11 +57,6 @@ pub mod ffi {
 
         pub fn HandleGeomCurve_Value(curve: &HandleGeomCurve, u: f64) -> UniquePtr<gp_Pnt>;
 
-        // General Shape Stuff
-        /// Takes a shape reference (typically one returned from a shape builder API) and puts
-        /// it in a unique_ptr.
-        pub fn new_shape(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
-
         // Collections
         type TopTools_ListOfShape;
         pub fn new_list_of_shape() -> UniquePtr<TopTools_ListOfShape>;
@@ -149,7 +144,13 @@ pub mod ffi {
         pub fn TopoDS_cast_to_vertex(shape: &TopoDS_Shape) -> &TopoDS_Vertex;
         pub fn TopoDS_cast_to_wire(shape: &TopoDS_Shape) -> &TopoDS_Wire;
         pub fn TopoDS_cast_to_edge(shape: &TopoDS_Shape) -> &TopoDS_Edge;
-        pub fn TopoDS_cast_to_face(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Face>;
+        pub fn TopoDS_cast_to_face(shape: &TopoDS_Shape) -> &TopoDS_Face;
+
+        pub fn TopoDS_Shape_to_owned(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
+        pub fn TopoDS_Vertex_to_owned(shape: &TopoDS_Vertex) -> UniquePtr<TopoDS_Vertex>;
+        pub fn TopoDS_Wire_to_owned(shape: &TopoDS_Wire) -> UniquePtr<TopoDS_Wire>;
+        pub fn TopoDS_Edge_to_owned(shape: &TopoDS_Edge) -> UniquePtr<TopoDS_Edge>;
+        pub fn TopoDS_Face_to_owned(shape: &TopoDS_Face) -> UniquePtr<TopoDS_Face>;
 
         pub fn IsNull(self: &TopoDS_Shape) -> bool;
         pub fn IsEqual(self: &TopoDS_Shape, other: &TopoDS_Shape) -> bool;

--- a/crates/opencascade/src/lib.rs
+++ b/crates/opencascade/src/lib.rs
@@ -1,8 +1,9 @@
 use cxx::UniquePtr;
 use opencascade_sys::ffi::{
-    new_point, new_shape, write_stl, BRepAlgoAPI_Cut_ctor, BRepFilletAPI_MakeChamfer_ctor,
+    new_point, write_stl, BRepAlgoAPI_Cut_ctor, BRepFilletAPI_MakeChamfer_ctor,
     BRepFilletAPI_MakeFillet_ctor, BRepMesh_IncrementalMesh_ctor, BRepPrimAPI_MakeBox_ctor,
-    StlAPI_Writer_ctor, TopAbs_ShapeEnum, TopExp_Explorer_ctor, TopoDS_Shape, TopoDS_cast_to_edge,
+    StlAPI_Writer_ctor, TopAbs_ShapeEnum, TopExp_Explorer_ctor, TopoDS_Shape,
+    TopoDS_Shape_to_owned, TopoDS_cast_to_edge,
 };
 use std::path::Path;
 
@@ -15,7 +16,7 @@ impl Shape {
     pub fn make_box(x: f64, y: f64, z: f64) -> Self {
         let point = new_point(0.0, 0.0, 0.0);
         let mut my_box = BRepPrimAPI_MakeBox_ctor(&point, x, y, z);
-        let shape = new_shape(my_box.pin_mut().Shape());
+        let shape = TopoDS_Shape_to_owned(my_box.pin_mut().Shape());
 
         Self { shape }
     }
@@ -44,7 +45,7 @@ impl Shape {
 
         let filleted_shape = make_fillet.pin_mut().Shape();
 
-        self.shape = new_shape(filleted_shape);
+        self.shape = TopoDS_Shape_to_owned(filleted_shape);
     }
 
     pub fn chamfer_edges(&mut self, distance: f64) {
@@ -59,13 +60,13 @@ impl Shape {
 
         let filleted_shape = make_chamfer.pin_mut().Shape();
 
-        self.shape = new_shape(filleted_shape);
+        self.shape = TopoDS_Shape_to_owned(filleted_shape);
     }
 
     pub fn subtract(&mut self, other: &Shape) {
         let mut cut_operation = BRepAlgoAPI_Cut_ctor(&self.shape, &other.shape);
 
         let cut_shape = cut_operation.pin_mut().Shape();
-        self.shape = new_shape(cut_shape);
+        self.shape = TopoDS_Shape_to_owned(cut_shape);
     }
 }


### PR DESCRIPTION
Currently the cast methods return either `&Something` or `UniquePtr<Something>` depending on convenience. This makes it hard to make a generic wrapper around the Explorer class since those values have different lifetimes. 

Here I make all casts return references and add a suite of `Something_to_owned` methods that can make those values `UniquePtr<Something>` on request. 

I also remove `new_shape` since it is now obsolete. 