### PR TITLE
Constructor template

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -44,7 +44,6 @@
 
 // Generic template constructor
 template <typename T, typename... Args> std::unique_ptr<T> construct_unique(Args... args) {
-  // return T(args...);
   return std::unique_ptr<T>(new T(args...));
 }
 
@@ -153,26 +152,6 @@ inline const TopoDS_Wire &TopoDS_cast_to_wire(const TopoDS_Shape &shape) { retur
 inline const TopoDS_Edge &TopoDS_cast_to_edge(const TopoDS_Shape &shape) { return TopoDS::Edge(shape); }
 
 inline const TopoDS_Face &TopoDS_cast_to_face(const TopoDS_Shape &shape) { return TopoDS::Face(shape); }
-
-inline std::unique_ptr<TopoDS_Shape> TopoDS_Shape_to_owned(const TopoDS_Shape &shape) {
-  return std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape(shape));
-}
-
-inline std::unique_ptr<TopoDS_Vertex> TopoDS_Vertex_to_owned(const TopoDS_Vertex &vertex) {
-  return std::unique_ptr<TopoDS_Vertex>(new TopoDS_Vertex(vertex));
-}
-
-inline std::unique_ptr<TopoDS_Wire> TopoDS_Wire_to_owned(const TopoDS_Wire &wire) {
-  return std::unique_ptr<TopoDS_Wire>(new TopoDS_Wire(wire));
-}
-
-inline std::unique_ptr<TopoDS_Edge> TopoDS_Edge_to_owned(const TopoDS_Edge &edge) {
-  return std::unique_ptr<TopoDS_Edge>(new TopoDS_Edge(edge));
-}
-
-inline std::unique_ptr<TopoDS_Face> TopoDS_Face_to_owned(const TopoDS_Face &face) {
-  return std::unique_ptr<TopoDS_Face>(new TopoDS_Face(face));
-}
 
 // Compound shapes
 inline std::unique_ptr<TopoDS_Shape> TopoDS_Compound_as_shape(std::unique_ptr<TopoDS_Compound> compound) {

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -60,18 +60,12 @@ typedef opencascade::handle<Geom2d_TrimmedCurve> HandleGeom2d_TrimmedCurve;
 typedef opencascade::handle<Geom_CylindricalSurface> HandleGeom_CylindricalSurface;
 
 // Handle stuff
-
 inline const HandleStandardType &DynamicType(const HandleGeomSurface &surface) { return surface->DynamicType(); }
 
 inline rust::String type_name(const HandleStandardType &handle) { return std::string(handle->Name()); }
 
 inline std::unique_ptr<gp_Pnt> HandleGeomCurve_Value(const HandleGeomCurve &curve, const Standard_Real U) {
   return std::unique_ptr<gp_Pnt>(new gp_Pnt(curve->Value(U)));
-}
-
-inline std::unique_ptr<HandleGeomCurve>
-new_HandleGeomCurve_from_HandleGeom_TrimmedCurve(const HandleGeomTrimmedCurve &trimmed_curve) {
-  return std::unique_ptr<HandleGeomCurve>(new opencascade::handle<Geom_Curve>(trimmed_curve));
 }
 
 inline std::unique_ptr<HandleGeomPlane> new_HandleGeomPlane_from_HandleGeomSurface(const HandleGeomSurface &surface) {
@@ -137,10 +131,6 @@ inline std::unique_ptr<gp_Vec> new_vec(double x, double y, double z) {
 }
 
 // Segment Stuff
-inline std::unique_ptr<GC_MakeSegment> GC_MakeSegment_point_point(const gp_Pnt &p1, const gp_Pnt &p2) {
-  return std::unique_ptr<GC_MakeSegment>(new GC_MakeSegment(p1, p2));
-}
-
 inline std::unique_ptr<HandleGeomTrimmedCurve> GC_MakeSegment_Value(const GC_MakeSegment &segment) {
   return std::unique_ptr<HandleGeomTrimmedCurve>(new opencascade::handle<Geom_TrimmedCurve>(segment.Value()));
 }
@@ -152,41 +142,8 @@ inline std::unique_ptr<HandleGeom2d_TrimmedCurve> GCE2d_MakeSegment_point_point(
 }
 
 // Arc stuff
-inline std::unique_ptr<GC_MakeArcOfCircle> GC_MakeArcOfCircle_point_point_point(const gp_Pnt &p1, const gp_Pnt &p2,
-                                                                                const gp_Pnt &p3) {
-  return std::unique_ptr<GC_MakeArcOfCircle>(new GC_MakeArcOfCircle(p1, p2, p3));
-}
-
 inline std::unique_ptr<HandleGeomTrimmedCurve> GC_MakeArcOfCircle_Value(const GC_MakeArcOfCircle &arc) {
   return std::unique_ptr<HandleGeomTrimmedCurve>(new opencascade::handle<Geom_TrimmedCurve>(arc.Value()));
-}
-
-// BRepBuilderAPI stuff
-inline std::unique_ptr<BRepBuilderAPI_MakeEdge>
-BRepBuilderAPI_MakeEdge_HandleGeomCurve(const HandleGeomCurve &geom_curve) {
-  return std::unique_ptr<BRepBuilderAPI_MakeEdge>(new BRepBuilderAPI_MakeEdge(geom_curve));
-}
-
-inline std::unique_ptr<BRepBuilderAPI_MakeEdge>
-BRepBuilderAPI_MakeEdge_CurveSurface2d(const HandleGeom2d_Curve &curve_handle,
-                                       const HandleGeomSurface &surface_handle) {
-  return std::unique_ptr<BRepBuilderAPI_MakeEdge>(new BRepBuilderAPI_MakeEdge(curve_handle, surface_handle));
-}
-
-inline std::unique_ptr<BRepBuilderAPI_MakeWire> BRepBuilderAPI_MakeWire_edge_edge_edge(const TopoDS_Edge &edge_1,
-                                                                                       const TopoDS_Edge &edge_2,
-                                                                                       const TopoDS_Edge &edge_3) {
-  return std::unique_ptr<BRepBuilderAPI_MakeWire>(new BRepBuilderAPI_MakeWire(edge_1, edge_2, edge_3));
-}
-
-inline std::unique_ptr<BRepBuilderAPI_MakeWire> BRepBuilderAPI_MakeWire_edge_edge(const TopoDS_Edge &edge_1,
-                                                                                  const TopoDS_Edge &edge_2) {
-  return std::unique_ptr<BRepBuilderAPI_MakeWire>(new BRepBuilderAPI_MakeWire(edge_1, edge_2));
-}
-
-inline std::unique_ptr<BRepBuilderAPI_MakeFace> BRepBuilderAPI_MakeFace_wire(const TopoDS_Wire &wire,
-                                                                             const Standard_Boolean only_plane) {
-  return std::unique_ptr<BRepBuilderAPI_MakeFace>(new BRepBuilderAPI_MakeFace(wire, only_plane));
 }
 
 // BRepLib
@@ -204,10 +161,6 @@ inline const gp_Ax1 &gp_OY() { return gp::OY(); }
 inline const gp_Ax1 &gp_OZ() { return gp::OZ(); }
 
 inline const gp_Dir &gp_DZ() { return gp::DZ(); }
-
-inline std::unique_ptr<gp_Ax3> gp_Ax3_from_gp_Ax2(const gp_Ax2 &axis) {
-  return std::unique_ptr<gp_Ax3>(new gp_Ax3(axis));
-}
 
 // Shape stuff
 inline const TopoDS_Vertex &TopoDS_cast_to_vertex(const TopoDS_Shape &shape) { return TopoDS::Vertex(shape); }

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -43,8 +43,7 @@
 #include <gp_Vec.hxx>
 
 // Generic template constructor
-template<typename T, typename... Args>
-std::unique_ptr<T> construct_unique(Args... args) {
+template <typename T, typename... Args> std::unique_ptr<T> construct_unique(Args... args) {
   // return T(args...);
   return std::unique_ptr<T>(new T(args...));
 }

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -74,10 +74,6 @@ inline std::unique_ptr<HandleGeomPlane> new_HandleGeomPlane_from_HandleGeomSurfa
 }
 
 // Collections
-inline std::unique_ptr<TopTools_ListOfShape> new_list_of_shape() {
-  return std::unique_ptr<TopTools_ListOfShape>(new TopTools_ListOfShape());
-}
-
 inline void shape_list_append_face(TopTools_ListOfShape &list, const TopoDS_Face &face) { list.Append(face); }
 
 // Geometry
@@ -115,19 +111,6 @@ HandleGeom2d_TrimmedCurve_to_curve(const HandleGeom2d_TrimmedCurve &trimmed_curv
 
 inline std::unique_ptr<gp_Pnt2d> ellipse_value(const HandleGeom2d_Ellipse &ellipse, double u) {
   return std::unique_ptr<gp_Pnt2d>(new gp_Pnt2d(ellipse->Value(u)));
-}
-
-// Point stuff
-inline std::unique_ptr<gp_Pnt> new_point(double x, double y, double z) {
-  return std::unique_ptr<gp_Pnt>(new gp_Pnt(x, y, z));
-}
-
-inline std::unique_ptr<gp_Pnt2d> new_point_2d(double x, double y) {
-  return std::unique_ptr<gp_Pnt2d>(new gp_Pnt2d(x, y));
-}
-
-inline std::unique_ptr<gp_Vec> new_vec(double x, double y, double z) {
-  return std::unique_ptr<gp_Vec>(new gp_Vec(x, y, z));
 }
 
 // Segment Stuff
@@ -199,13 +182,6 @@ inline std::unique_ptr<TopoDS_Shape> TopoDS_Compound_as_shape(std::unique_ptr<To
 inline const TopoDS_Builder &BRep_Builder_upcast_to_topods_builder(const BRep_Builder &builder) { return builder; }
 
 // Transforms
-inline std::unique_ptr<gp_Trsf> new_transform() { return std::unique_ptr<gp_Trsf>(new gp_Trsf()); }
-
-inline std::unique_ptr<BRepBuilderAPI_Transform>
-BRepBuilderAPI_Transform_ctor(const TopoDS_Shape &shape, const gp_Trsf &transform, const Standard_Boolean copy) {
-  return std::unique_ptr<BRepBuilderAPI_Transform>(new BRepBuilderAPI_Transform(shape, transform, copy));
-}
-
 inline std::unique_ptr<HandleGeomSurface> BRep_Tool_Surface(const TopoDS_Face &face) {
   return std::unique_ptr<HandleGeomSurface>(new opencascade::handle<Geom_Surface>(BRep_Tool::Surface(face)));
 }

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -42,6 +42,13 @@
 #include <gp_Trsf.hxx>
 #include <gp_Vec.hxx>
 
+// Generic template constructor
+template<typename T, typename... Args>
+std::unique_ptr<T> construct_unique(Args... args) {
+  // return T(args...);
+  return std::unique_ptr<T>(new T(args...));
+}
+
 // Handles
 typedef opencascade::handle<Standard_Type> HandleStandardType;
 typedef opencascade::handle<Geom_Curve> HandleGeomCurve;
@@ -52,11 +59,6 @@ typedef opencascade::handle<Geom2d_Curve> HandleGeom2d_Curve;
 typedef opencascade::handle<Geom2d_Ellipse> HandleGeom2d_Ellipse;
 typedef opencascade::handle<Geom2d_TrimmedCurve> HandleGeom2d_TrimmedCurve;
 typedef opencascade::handle<Geom_CylindricalSurface> HandleGeom_CylindricalSurface;
-
-// Runtime
-inline std::unique_ptr<Message_ProgressRange> Message_ProgressRange_ctor() {
-  return std::unique_ptr<Message_ProgressRange>(new Message_ProgressRange());
-}
 
 // Handle stuff
 
@@ -172,10 +174,6 @@ BRepBuilderAPI_MakeEdge_CurveSurface2d(const HandleGeom2d_Curve &curve_handle,
   return std::unique_ptr<BRepBuilderAPI_MakeEdge>(new BRepBuilderAPI_MakeEdge(curve_handle, surface_handle));
 }
 
-inline std::unique_ptr<BRepBuilderAPI_MakeWire> BRepBuilderAPI_MakeWire_ctor() {
-  return std::unique_ptr<BRepBuilderAPI_MakeWire>(new BRepBuilderAPI_MakeWire());
-}
-
 inline std::unique_ptr<BRepBuilderAPI_MakeWire> BRepBuilderAPI_MakeWire_edge_edge_edge(const TopoDS_Edge &edge_1,
                                                                                        const TopoDS_Edge &edge_2,
                                                                                        const TopoDS_Edge &edge_3) {
@@ -192,80 +190,13 @@ inline std::unique_ptr<BRepBuilderAPI_MakeFace> BRepBuilderAPI_MakeFace_wire(con
   return std::unique_ptr<BRepBuilderAPI_MakeFace>(new BRepBuilderAPI_MakeFace(wire, only_plane));
 }
 
-// Primitives
-inline std::unique_ptr<BRepPrimAPI_MakePrism> BRepPrimAPI_MakePrism_ctor(const TopoDS_Shape &shape, const gp_Vec &vec,
-                                                                         const Standard_Boolean copy,
-                                                                         const Standard_Boolean canonize) {
-  return std::unique_ptr<BRepPrimAPI_MakePrism>(new BRepPrimAPI_MakePrism(shape, vec, copy, canonize));
-}
-
-inline std::unique_ptr<BRepPrimAPI_MakeRevol> BRepPrimAPI_MakeRevol_ctor(const TopoDS_Shape &shape, const gp_Ax1 &axis,
-                                                                         const Standard_Real angle,
-                                                                         const Standard_Boolean copy) {
-  return std::unique_ptr<BRepPrimAPI_MakeRevol>(new BRepPrimAPI_MakeRevol(shape, axis, angle, copy));
-}
-
-inline std::unique_ptr<BRepPrimAPI_MakeCylinder>
-BRepPrimAPI_MakeCylinder_ctor(const gp_Ax2 &coord_system, const Standard_Real radius, const Standard_Real height) {
-  return std::unique_ptr<BRepPrimAPI_MakeCylinder>(new BRepPrimAPI_MakeCylinder(coord_system, radius, height));
-}
-
-inline std::unique_ptr<BRepPrimAPI_MakeBox> BRepPrimAPI_MakeBox_ctor(const gp_Pnt &point, double dx, double dy,
-                                                                     double dz) {
-  return std::unique_ptr<BRepPrimAPI_MakeBox>(new BRepPrimAPI_MakeBox(point, dx, dy, dz));
-}
-
-inline std::unique_ptr<BRepPrimAPI_MakeSphere> BRepPrimAPI_MakeSphere_ctor(double r) {
-  return std::unique_ptr<BRepPrimAPI_MakeSphere>(new BRepPrimAPI_MakeSphere(r));
-}
-
 // BRepLib
 inline bool BRepLibBuildCurves3d(const TopoDS_Shape &shape) { return BRepLib::BuildCurves3d(shape); }
-
-// Boolean operations
-inline std::unique_ptr<BRepAlgoAPI_Fuse> BRepAlgoAPI_Fuse_ctor(const TopoDS_Shape &shape_1,
-                                                               const TopoDS_Shape &shape_2) {
-  return std::unique_ptr<BRepAlgoAPI_Fuse>(new BRepAlgoAPI_Fuse(shape_1, shape_2));
-}
-
-inline std::unique_ptr<BRepAlgoAPI_Cut> BRepAlgoAPI_Cut_ctor(const TopoDS_Shape &shape_1, const TopoDS_Shape &shape_2) {
-  return std::unique_ptr<BRepAlgoAPI_Cut>(new BRepAlgoAPI_Cut(shape_1, shape_2));
-}
-
-inline std::unique_ptr<BRepAlgoAPI_Common> BRepAlgoAPI_Common_ctor(const TopoDS_Shape &shape_1,
-                                                                   const TopoDS_Shape &shape_2) {
-  return std::unique_ptr<BRepAlgoAPI_Common>(new BRepAlgoAPI_Common(shape_1, shape_2));
-}
-
-inline std::unique_ptr<BRepAlgoAPI_Section> BRepAlgoAPI_Section_ctor(const TopoDS_Shape &shape_1,
-                                                                     const TopoDS_Shape &shape_2) {
-  return std::unique_ptr<BRepAlgoAPI_Section>(new BRepAlgoAPI_Section(shape_1, shape_2));
-}
-
-// Fillets
-inline std::unique_ptr<BRepFilletAPI_MakeFillet> BRepFilletAPI_MakeFillet_ctor(const TopoDS_Shape &shape) {
-  return std::unique_ptr<BRepFilletAPI_MakeFillet>(new BRepFilletAPI_MakeFillet(shape));
-}
-
-// Chamfers
-inline std::unique_ptr<BRepFilletAPI_MakeChamfer> BRepFilletAPI_MakeChamfer_ctor(const TopoDS_Shape &shape) {
-  return std::unique_ptr<BRepFilletAPI_MakeChamfer>(new BRepFilletAPI_MakeChamfer(shape));
-}
-
-// Solids
-inline std::unique_ptr<BRepOffsetAPI_MakeThickSolid> BRepOffsetAPI_MakeThickSolid_ctor() {
-  return std::unique_ptr<BRepOffsetAPI_MakeThickSolid>(new BRepOffsetAPI_MakeThickSolid());
-}
 
 inline void MakeThickSolidByJoin(BRepOffsetAPI_MakeThickSolid &make_thick_solid, const TopoDS_Shape &shape,
                                  const TopTools_ListOfShape &closing_faces, const Standard_Real offset,
                                  const Standard_Real tolerance) {
   make_thick_solid.MakeThickSolidByJoin(shape, closing_faces, offset, tolerance);
-}
-
-// Lofting
-inline std::unique_ptr<BRepOffsetAPI_ThruSections> BRepOffsetAPI_ThruSections_ctor(bool is_solid) {
-  return std::unique_ptr<BRepOffsetAPI_ThruSections>(new BRepOffsetAPI_ThruSections(is_solid));
 }
 
 // Geometric processing
@@ -275,20 +206,8 @@ inline const gp_Ax1 &gp_OZ() { return gp::OZ(); }
 
 inline const gp_Dir &gp_DZ() { return gp::DZ(); }
 
-inline std::unique_ptr<gp_Ax2> gp_Ax2_ctor(const gp_Pnt &origin, const gp_Dir &main_dir) {
-  return std::unique_ptr<gp_Ax2>(new gp_Ax2(origin, main_dir));
-}
-
 inline std::unique_ptr<gp_Ax3> gp_Ax3_from_gp_Ax2(const gp_Ax2 &axis) {
   return std::unique_ptr<gp_Ax3>(new gp_Ax3(axis));
-}
-
-inline std::unique_ptr<gp_Dir2d> gp_Dir2d_ctor(double x, double y) {
-  return std::unique_ptr<gp_Dir2d>(new gp_Dir2d(x, y));
-}
-
-inline std::unique_ptr<gp_Ax2d> gp_Ax2d_ctor(const gp_Pnt2d &point, const gp_Dir2d &dir) {
-  return std::unique_ptr<gp_Ax2d>(new gp_Ax2d(point, dir));
 }
 
 // Shape stuff
@@ -325,12 +244,6 @@ inline std::unique_ptr<TopoDS_Shape> TopoDS_Compound_as_shape(std::unique_ptr<To
   return compound;
 }
 
-inline std::unique_ptr<TopoDS_Compound> TopoDS_Compound_ctor() {
-  return std::unique_ptr<TopoDS_Compound>(new TopoDS_Compound());
-}
-
-inline std::unique_ptr<BRep_Builder> BRep_Builder_ctor() { return std::unique_ptr<BRep_Builder>(new BRep_Builder()); }
-
 inline const TopoDS_Builder &BRep_Builder_upcast_to_topods_builder(const BRep_Builder &builder) { return builder; }
 
 // Transforms
@@ -339,12 +252,6 @@ inline std::unique_ptr<gp_Trsf> new_transform() { return std::unique_ptr<gp_Trsf
 inline std::unique_ptr<BRepBuilderAPI_Transform>
 BRepBuilderAPI_Transform_ctor(const TopoDS_Shape &shape, const gp_Trsf &transform, const Standard_Boolean copy) {
   return std::unique_ptr<BRepBuilderAPI_Transform>(new BRepBuilderAPI_Transform(shape, transform, copy));
-}
-
-// Topology Explorer
-inline std::unique_ptr<TopExp_Explorer> TopExp_Explorer_ctor(const TopoDS_Shape &shape,
-                                                             const TopAbs_ShapeEnum to_find) {
-  return std::unique_ptr<TopExp_Explorer>(new TopExp_Explorer(shape, to_find));
 }
 
 inline std::unique_ptr<HandleGeomSurface> BRep_Tool_Surface(const TopoDS_Face &face) {
@@ -365,16 +272,6 @@ inline std::unique_ptr<TopoDS_Shape> ExplorerCurrentShape(const TopExp_Explorer 
 }
 
 // Data export
-inline std::unique_ptr<StlAPI_Writer> StlAPI_Writer_ctor() {
-  return std::unique_ptr<StlAPI_Writer>(new StlAPI_Writer());
-}
-
 inline bool write_stl(StlAPI_Writer &writer, const TopoDS_Shape &theShape, rust::String theFileName) {
   return writer.Write(theShape, theFileName.c_str());
-}
-
-// Triangulation
-inline std::unique_ptr<BRepMesh_IncrementalMesh> BRepMesh_IncrementalMesh_ctor(const TopoDS_Shape &shape,
-                                                                               double deflection) {
-  return std::unique_ptr<BRepMesh_IncrementalMesh>(new BRepMesh_IncrementalMesh(shape, deflection));
 }

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -161,11 +161,20 @@ pub mod ffi {
         pub fn TopoDS_cast_to_edge(shape: &TopoDS_Shape) -> &TopoDS_Edge;
         pub fn TopoDS_cast_to_face(shape: &TopoDS_Shape) -> &TopoDS_Face;
 
-        pub fn TopoDS_Shape_to_owned(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
-        pub fn TopoDS_Vertex_to_owned(shape: &TopoDS_Vertex) -> UniquePtr<TopoDS_Vertex>;
-        pub fn TopoDS_Wire_to_owned(shape: &TopoDS_Wire) -> UniquePtr<TopoDS_Wire>;
-        pub fn TopoDS_Edge_to_owned(shape: &TopoDS_Edge) -> UniquePtr<TopoDS_Edge>;
-        pub fn TopoDS_Face_to_owned(shape: &TopoDS_Face) -> UniquePtr<TopoDS_Face>;
+        #[rust_name = "TopoDS_Shape_to_owned"]
+        pub fn construct_unique(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
+
+        #[rust_name = "TopoDS_Vertex_to_owned"]
+        pub fn construct_unique(shape: &TopoDS_Vertex) -> UniquePtr<TopoDS_Vertex>;
+
+        #[rust_name = "TopoDS_Wire_to_owned"]
+        pub fn construct_unique(shape: &TopoDS_Wire) -> UniquePtr<TopoDS_Wire>;
+
+        #[rust_name = "TopoDS_Edge_to_owned"]
+        pub fn construct_unique(shape: &TopoDS_Edge) -> UniquePtr<TopoDS_Edge>;
+
+        #[rust_name = "TopoDS_Face_to_owned"]
+        pub fn construct_unique(shape: &TopoDS_Face) -> UniquePtr<TopoDS_Face>;
 
         pub fn IsNull(self: &TopoDS_Shape) -> bool;
         pub fn IsEqual(self: &TopoDS_Shape, other: &TopoDS_Shape) -> bool;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -39,7 +39,8 @@ pub mod ffi {
         pub fn DynamicType(surface: &HandleGeomSurface) -> &HandleStandardType;
         pub fn type_name(handle: &HandleStandardType) -> String;
 
-        pub fn new_HandleGeomCurve_from_HandleGeom_TrimmedCurve(
+        #[rust_name = "new_HandleGeomCurve_from_HandleGeom_TrimmedCurve"]
+        pub fn construct_unique(
             trimmed_curve_handle: &HandleGeomTrimmedCurve,
         ) -> UniquePtr<HandleGeomCurve>;
 
@@ -75,7 +76,6 @@ pub mod ffi {
 
         pub fn handle_geom_plane_location(plane: &HandleGeomPlane) -> &gp_Pnt;
 
-        // TODO - return a Handle?
         pub fn Geom_CylindricalSurface_ctor(
             axis: &gp_Ax3,
             radius: f64,
@@ -126,7 +126,10 @@ pub mod ffi {
         // Segments
         type GC_MakeSegment;
         type GCE2d_MakeSegment;
-        pub fn GC_MakeSegment_point_point(p1: &gp_Pnt, p2: &gp_Pnt) -> UniquePtr<GC_MakeSegment>;
+
+        #[rust_name = "GC_MakeSegment_point_point"]
+        pub fn construct_unique(p1: &gp_Pnt, p2: &gp_Pnt) -> UniquePtr<GC_MakeSegment>;
+
         pub fn GC_MakeSegment_Value(arc: &GC_MakeSegment) -> UniquePtr<HandleGeomTrimmedCurve>;
         pub fn GCE2d_MakeSegment_point_point(
             p1: &gp_Pnt2d,
@@ -135,11 +138,14 @@ pub mod ffi {
 
         // Arcs
         type GC_MakeArcOfCircle;
-        pub fn GC_MakeArcOfCircle_point_point_point(
+
+        #[rust_name = "GC_MakeArcOfCircle_point_point_point"]
+        pub fn construct_unique(
             p1: &gp_Pnt,
             p2: &gp_Pnt,
             p3: &gp_Pnt,
         ) -> UniquePtr<GC_MakeArcOfCircle>;
+
         pub fn GC_MakeArcOfCircle_Value(
             arc: &GC_MakeArcOfCircle,
         ) -> UniquePtr<HandleGeomTrimmedCurve>;
@@ -186,13 +192,18 @@ pub mod ffi {
         // BRepBuilder
         type BRepBuilderAPI_MakeEdge;
         type TopoDS_Vertex;
-        pub fn BRepBuilderAPI_MakeEdge_HandleGeomCurve(
+
+        #[rust_name = "BRepBuilderAPI_MakeEdge_HandleGeomCurve"]
+        pub fn construct_unique(
             geom_curve_handle: &HandleGeomCurve,
         ) -> UniquePtr<BRepBuilderAPI_MakeEdge>;
-        pub fn BRepBuilderAPI_MakeEdge_CurveSurface2d(
+
+        #[rust_name = "BRepBuilderAPI_MakeEdge_CurveSurface2d"]
+        pub fn construct_unique(
             curve_handle: &HandleGeom2d_Curve,
             surface_handle: &HandleGeomSurface,
         ) -> UniquePtr<BRepBuilderAPI_MakeEdge>;
+
         pub fn Vertex1(self: &BRepBuilderAPI_MakeEdge) -> &TopoDS_Vertex;
         pub fn Edge(self: Pin<&mut BRepBuilderAPI_MakeEdge>) -> &TopoDS_Edge;
         pub fn Build(self: Pin<&mut BRepBuilderAPI_MakeEdge>, progress: &Message_ProgressRange);
@@ -203,25 +214,32 @@ pub mod ffi {
         #[rust_name = "BRepBuilderAPI_MakeWire_ctor"]
         pub fn construct_unique() -> UniquePtr<BRepBuilderAPI_MakeWire>;
 
-        pub fn BRepBuilderAPI_MakeWire_edge_edge(
+        #[rust_name = "BRepBuilderAPI_MakeWire_edge_edge"]
+        pub fn construct_unique(
             edge_1: &TopoDS_Edge,
             edge_2: &TopoDS_Edge,
         ) -> UniquePtr<BRepBuilderAPI_MakeWire>;
-        pub fn BRepBuilderAPI_MakeWire_edge_edge_edge(
+
+        #[rust_name = "BRepBuilderAPI_MakeWire_edge_edge_edge"]
+        pub fn construct_unique(
             edge_1: &TopoDS_Edge,
             edge_2: &TopoDS_Edge,
             edge_3: &TopoDS_Edge,
         ) -> UniquePtr<BRepBuilderAPI_MakeWire>;
+
         pub fn Shape(self: Pin<&mut BRepBuilderAPI_MakeWire>) -> &TopoDS_Shape;
         pub fn Wire(self: Pin<&mut BRepBuilderAPI_MakeWire>) -> &TopoDS_Wire;
         pub fn Build(self: Pin<&mut BRepBuilderAPI_MakeWire>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepBuilderAPI_MakeWire) -> bool;
 
         type BRepBuilderAPI_MakeFace;
-        pub fn BRepBuilderAPI_MakeFace_wire(
+
+        #[rust_name = "BRepBuilderAPI_MakeFace_wire"]
+        pub fn construct_unique(
             wire: &TopoDS_Wire,
             only_plane: bool,
         ) -> UniquePtr<BRepBuilderAPI_MakeFace>;
+
         pub fn Shape(self: Pin<&mut BRepBuilderAPI_MakeFace>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepBuilderAPI_MakeFace>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepBuilderAPI_MakeFace) -> bool;
@@ -420,7 +438,8 @@ pub mod ffi {
         #[rust_name = "gp_Ax2_ctor"]
         pub fn construct_unique(origin: &gp_Pnt, main_dir: &gp_Dir) -> UniquePtr<gp_Ax2>;
 
-        pub fn gp_Ax3_from_gp_Ax2(axis: &gp_Ax2) -> UniquePtr<gp_Ax3>;
+        #[rust_name = "gp_Ax3_from_gp_Ax2"]
+        pub fn construct_unique(axis: &gp_Ax2) -> UniquePtr<gp_Ax3>;
 
         #[rust_name = "gp_Dir2d_ctor"]
         pub fn construct_unique(x: f64, y: f64) -> UniquePtr<gp_Dir2d>;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -21,7 +21,9 @@ pub mod ffi {
 
         // Runtime
         type Message_ProgressRange;
-        pub fn Message_ProgressRange_ctor() -> UniquePtr<Message_ProgressRange>;
+
+        #[rust_name = "Message_ProgressRange_ctor"]
+        pub fn construct_unique() -> UniquePtr<Message_ProgressRange>;
 
         // Handles
         type HandleStandardType;
@@ -59,7 +61,9 @@ pub mod ffi {
 
         // Collections
         type TopTools_ListOfShape;
-        pub fn new_list_of_shape() -> UniquePtr<TopTools_ListOfShape>;
+
+        #[rust_name = "new_list_of_shape"]
+        pub fn construct_unique() -> UniquePtr<TopTools_ListOfShape>;
         pub fn shape_list_append_face(list: Pin<&mut TopTools_ListOfShape>, face: &TopoDS_Face);
 
         // Geometry
@@ -103,16 +107,21 @@ pub mod ffi {
         type gp_Pnt;
         type gp_Pnt2d;
 
-        pub fn new_point(x: f64, y: f64, z: f64) -> UniquePtr<gp_Pnt>;
+        #[rust_name = "new_point"]
+        pub fn construct_unique(x: f64, y: f64, z: f64) -> UniquePtr<gp_Pnt>;
+
         pub fn X(self: &gp_Pnt) -> f64;
         pub fn Y(self: &gp_Pnt) -> f64;
         pub fn Z(self: &gp_Pnt) -> f64;
         pub fn Distance(self: &gp_Pnt, other: &gp_Pnt) -> f64;
 
-        pub fn new_point_2d(x: f64, y: f64) -> UniquePtr<gp_Pnt2d>;
+        #[rust_name = "new_point_2d"]
+        pub fn construct_unique(x: f64, y: f64) -> UniquePtr<gp_Pnt2d>;
 
         type gp_Vec;
-        pub fn new_vec(x: f64, y: f64, z: f64) -> UniquePtr<gp_Vec>;
+
+        #[rust_name = "new_vec"]
+        pub fn construct_unique(x: f64, y: f64, z: f64) -> UniquePtr<gp_Vec>;
 
         // Segments
         type GC_MakeSegment;
@@ -163,8 +172,13 @@ pub mod ffi {
 
         type BRep_Builder;
         type TopoDS_Builder;
-        pub fn TopoDS_Compound_ctor() -> UniquePtr<TopoDS_Compound>;
-        pub fn BRep_Builder_ctor() -> UniquePtr<BRep_Builder>;
+
+        #[rust_name = "TopoDS_Compound_ctor"]
+        pub fn construct_unique() -> UniquePtr<TopoDS_Compound>;
+
+        #[rust_name = "BRep_Builder_ctor"]
+        pub fn construct_unique() -> UniquePtr<BRep_Builder>;
+
         pub fn BRep_Builder_upcast_to_topods_builder(builder: &BRep_Builder) -> &TopoDS_Builder;
         pub fn MakeCompound(self: &TopoDS_Builder, compound: Pin<&mut TopoDS_Compound>);
         pub fn Add(self: &TopoDS_Builder, shape: Pin<&mut TopoDS_Shape>, compound: &TopoDS_Shape);
@@ -185,7 +199,10 @@ pub mod ffi {
         pub fn IsDone(self: &BRepBuilderAPI_MakeEdge) -> bool;
 
         type BRepBuilderAPI_MakeWire;
-        pub fn BRepBuilderAPI_MakeWire_ctor() -> UniquePtr<BRepBuilderAPI_MakeWire>;
+
+        #[rust_name = "BRepBuilderAPI_MakeWire_ctor"]
+        pub fn construct_unique() -> UniquePtr<BRepBuilderAPI_MakeWire>;
+
         pub fn BRepBuilderAPI_MakeWire_edge_edge(
             edge_1: &TopoDS_Edge,
             edge_2: &TopoDS_Edge,
@@ -211,23 +228,29 @@ pub mod ffi {
 
         // Primitives
         type BRepPrimAPI_MakePrism;
-        pub fn BRepPrimAPI_MakePrism_ctor(
+
+        #[rust_name = "BRepPrimAPI_MakePrism_ctor"]
+        pub fn construct_unique(
             shape: &TopoDS_Shape,
             vec: &gp_Vec,
             copy: bool,
             canonize: bool,
         ) -> UniquePtr<BRepPrimAPI_MakePrism>;
+
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakePrism>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepPrimAPI_MakePrism>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakePrism) -> bool;
 
         type BRepPrimAPI_MakeRevol;
-        pub fn BRepPrimAPI_MakeRevol_ctor(
+
+        #[rust_name = "BRepPrimAPI_MakeRevol_ctor"]
+        pub fn construct_unique(
             shape: &TopoDS_Shape,
             axis: &gp_Ax1,
             angle: f64,
             copy: bool,
         ) -> UniquePtr<BRepPrimAPI_MakeRevol>;
+
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeRevol>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepPrimAPI_MakeRevol>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakeRevol) -> bool;
@@ -239,28 +262,37 @@ pub mod ffi {
         pub fn Add(self: Pin<&mut BRepBuilderAPI_MakeWire>, wire: &TopoDS_Wire);
 
         type BRepPrimAPI_MakeCylinder;
-        pub fn BRepPrimAPI_MakeCylinder_ctor(
+
+        #[rust_name = "BRepPrimAPI_MakeCylinder_ctor"]
+        pub fn construct_unique(
             coord_system: &gp_Ax2,
             radius: f64,
             height: f64,
         ) -> UniquePtr<BRepPrimAPI_MakeCylinder>;
+
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeCylinder>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepPrimAPI_MakeCylinder>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakeCylinder) -> bool;
 
         type BRepPrimAPI_MakeBox;
-        pub fn BRepPrimAPI_MakeBox_ctor(
+
+        #[rust_name = "BRepPrimAPI_MakeBox_ctor"]
+        pub fn construct_unique(
             point: &gp_Pnt,
             dx: f64,
             dy: f64,
             dz: f64,
         ) -> UniquePtr<BRepPrimAPI_MakeBox>;
+
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeBox>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepPrimAPI_MakeBox>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakeBox) -> bool;
 
         type BRepPrimAPI_MakeSphere;
-        pub fn BRepPrimAPI_MakeSphere_ctor(r: f64) -> UniquePtr<BRepPrimAPI_MakeSphere>;
+
+        #[rust_name = "BRepPrimAPI_MakeSphere_ctor"]
+        pub fn construct_unique(r: f64) -> UniquePtr<BRepPrimAPI_MakeSphere>;
+
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeSphere>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepPrimAPI_MakeSphere>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepPrimAPI_MakeSphere) -> bool;
@@ -270,9 +302,10 @@ pub mod ffi {
 
         // Fillets
         type BRepFilletAPI_MakeFillet;
-        pub fn BRepFilletAPI_MakeFillet_ctor(
-            shape: &TopoDS_Shape,
-        ) -> UniquePtr<BRepFilletAPI_MakeFillet>;
+
+        #[rust_name = "BRepFilletAPI_MakeFillet_ctor"]
+        pub fn construct_unique(shape: &TopoDS_Shape) -> UniquePtr<BRepFilletAPI_MakeFillet>;
+
         #[rust_name = "add_edge"]
         pub fn Add(self: Pin<&mut BRepFilletAPI_MakeFillet>, radius: f64, edge: &TopoDS_Edge);
         pub fn Shape(self: Pin<&mut BRepFilletAPI_MakeFillet>) -> &TopoDS_Shape;
@@ -281,9 +314,10 @@ pub mod ffi {
 
         // Chamfers
         type BRepFilletAPI_MakeChamfer;
-        pub fn BRepFilletAPI_MakeChamfer_ctor(
-            shape: &TopoDS_Shape,
-        ) -> UniquePtr<BRepFilletAPI_MakeChamfer>;
+
+        #[rust_name = "BRepFilletAPI_MakeChamfer_ctor"]
+        pub fn construct_unique(shape: &TopoDS_Shape) -> UniquePtr<BRepFilletAPI_MakeChamfer>;
+
         #[rust_name = "add_edge"]
         pub fn Add(self: Pin<&mut BRepFilletAPI_MakeChamfer>, distance: f64, edge: &TopoDS_Edge);
         pub fn Shape(self: Pin<&mut BRepFilletAPI_MakeChamfer>) -> &TopoDS_Shape;
@@ -292,7 +326,10 @@ pub mod ffi {
 
         // Solids
         type BRepOffsetAPI_MakeThickSolid;
-        pub fn BRepOffsetAPI_MakeThickSolid_ctor() -> UniquePtr<BRepOffsetAPI_MakeThickSolid>;
+
+        #[rust_name = "BRepOffsetAPI_MakeThickSolid_ctor"]
+        pub fn construct_unique() -> UniquePtr<BRepOffsetAPI_MakeThickSolid>;
+
         pub fn MakeThickSolidByJoin(
             make_thick_solid: Pin<&mut BRepOffsetAPI_MakeThickSolid>,
             shape: &TopoDS_Shape,
@@ -309,9 +346,10 @@ pub mod ffi {
 
         // Lofting
         type BRepOffsetAPI_ThruSections;
-        pub fn BRepOffsetAPI_ThruSections_ctor(
-            is_solid: bool,
-        ) -> UniquePtr<BRepOffsetAPI_ThruSections>;
+
+        #[rust_name = "BRepOffsetAPI_ThruSections_ctor"]
+        pub fn construct_unique(is_solid: bool) -> UniquePtr<BRepOffsetAPI_ThruSections>;
+
         pub fn AddWire(self: Pin<&mut BRepOffsetAPI_ThruSections>, wire: &TopoDS_Wire);
         pub fn CheckCompatibility(self: Pin<&mut BRepOffsetAPI_ThruSections>, check: bool);
         pub fn Shape(self: Pin<&mut BRepOffsetAPI_ThruSections>) -> &TopoDS_Shape;
@@ -320,37 +358,49 @@ pub mod ffi {
 
         // Boolean Operations
         type BRepAlgoAPI_Fuse;
-        pub fn BRepAlgoAPI_Fuse_ctor(
+
+        #[rust_name = "BRepAlgoAPI_Fuse_ctor"]
+        pub fn construct_unique(
             shape_1: &TopoDS_Shape,
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Fuse>;
+
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Fuse>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepAlgoAPI_Fuse>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Fuse) -> bool;
 
         type BRepAlgoAPI_Cut;
-        pub fn BRepAlgoAPI_Cut_ctor(
+
+        #[rust_name = "BRepAlgoAPI_Cut_ctor"]
+        pub fn construct_unique(
             shape_1: &TopoDS_Shape,
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Cut>;
+
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Cut>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepAlgoAPI_Cut>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Cut) -> bool;
 
         type BRepAlgoAPI_Common;
-        pub fn BRepAlgoAPI_Common_ctor(
+
+        #[rust_name = "BRepAlgoAPI_Common_ctor"]
+        pub fn construct_unique(
             shape_1: &TopoDS_Shape,
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Common>;
+
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Common>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepAlgoAPI_Common>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Common) -> bool;
 
         type BRepAlgoAPI_Section;
-        pub fn BRepAlgoAPI_Section_ctor(
+
+        #[rust_name = "BRepAlgoAPI_Section_ctor"]
+        pub fn construct_unique(
             shape_1: &TopoDS_Shape,
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Section>;
+
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Section>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepAlgoAPI_Section>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Section) -> bool;
@@ -367,14 +417,22 @@ pub mod ffi {
         pub fn gp_OZ() -> &'static gp_Ax1;
         pub fn gp_DZ() -> &'static gp_Dir;
 
-        pub fn gp_Ax2_ctor(origin: &gp_Pnt, main_dir: &gp_Dir) -> UniquePtr<gp_Ax2>;
+        #[rust_name = "gp_Ax2_ctor"]
+        pub fn construct_unique(origin: &gp_Pnt, main_dir: &gp_Dir) -> UniquePtr<gp_Ax2>;
+
         pub fn gp_Ax3_from_gp_Ax2(axis: &gp_Ax2) -> UniquePtr<gp_Ax3>;
-        pub fn gp_Dir2d_ctor(x: f64, y: f64) -> UniquePtr<gp_Dir2d>;
-        pub fn gp_Ax2d_ctor(point: &gp_Pnt2d, dir: &gp_Dir2d) -> UniquePtr<gp_Ax2d>;
+
+        #[rust_name = "gp_Dir2d_ctor"]
+        pub fn construct_unique(x: f64, y: f64) -> UniquePtr<gp_Dir2d>;
+
+        #[rust_name = "gp_Ax2d_ctor"]
+        pub fn construct_unique(point: &gp_Pnt2d, dir: &gp_Dir2d) -> UniquePtr<gp_Ax2d>;
 
         // Transforms
         type gp_Trsf;
-        pub fn new_transform() -> UniquePtr<gp_Trsf>;
+
+        #[rust_name = "new_transform"]
+        pub fn construct_unique() -> UniquePtr<gp_Trsf>;
 
         #[rust_name = "set_mirror_axis"]
         pub fn SetMirror(self: Pin<&mut gp_Trsf>, axis: &gp_Ax1);
@@ -383,11 +441,14 @@ pub mod ffi {
         pub fn SetTranslation(self: Pin<&mut gp_Trsf>, point1: &gp_Pnt, point2: &gp_Pnt);
 
         type BRepBuilderAPI_Transform;
-        pub fn BRepBuilderAPI_Transform_ctor(
+
+        #[rust_name = "BRepBuilderAPI_Transform_ctor"]
+        pub fn construct_unique(
             shape: &TopoDS_Shape,
             transform: &gp_Trsf,
             copy: bool,
         ) -> UniquePtr<BRepBuilderAPI_Transform>;
+
         pub fn Shape(self: Pin<&mut BRepBuilderAPI_Transform>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepBuilderAPI_Transform>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepBuilderAPI_Transform) -> bool;
@@ -395,10 +456,13 @@ pub mod ffi {
         // Topology Explorer
         type TopExp_Explorer;
         type TopAbs_ShapeEnum;
-        pub fn TopExp_Explorer_ctor(
+
+        #[rust_name = "TopExp_Explorer_ctor"]
+        pub fn construct_unique(
             shape: &TopoDS_Shape,
             to_find: TopAbs_ShapeEnum,
         ) -> UniquePtr<TopExp_Explorer>;
+
         pub fn More(self: &TopExp_Explorer) -> bool;
         pub fn Next(self: Pin<&mut TopExp_Explorer>);
         pub fn ExplorerCurrentShape(explorer: &TopExp_Explorer) -> UniquePtr<TopoDS_Shape>;
@@ -414,7 +478,10 @@ pub mod ffi {
 
         // Data export
         type StlAPI_Writer;
-        pub fn StlAPI_Writer_ctor() -> UniquePtr<StlAPI_Writer>;
+
+        #[rust_name = "StlAPI_Writer_ctor"]
+        pub fn construct_unique() -> UniquePtr<StlAPI_Writer>;
+
         // pub fn Write(self: Pin<&mut StlAPI_Writer>, shape: &TopoDS_Shape, filename: &c_char) -> bool;
         pub fn write_stl(
             writer: Pin<&mut StlAPI_Writer>,
@@ -424,10 +491,13 @@ pub mod ffi {
 
         // Triangulation
         type BRepMesh_IncrementalMesh;
-        pub fn BRepMesh_IncrementalMesh_ctor(
+
+        #[rust_name = "BRepMesh_IncrementalMesh_ctor"]
+        pub fn construct_unique(
             shape: &TopoDS_Shape,
             deflection: f64,
         ) -> UniquePtr<BRepMesh_IncrementalMesh>;
+
         pub fn Shape(self: &BRepMesh_IncrementalMesh) -> &TopoDS_Shape;
         pub fn IsDone(self: &BRepMesh_IncrementalMesh) -> bool;
     }

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -22,8 +22,8 @@ pub mod ffi {
         // Runtime
         type Message_ProgressRange;
 
-        #[rust_name = "Message_ProgressRange_ctor"]
-        pub fn construct_unique() -> UniquePtr<Message_ProgressRange>;
+        #[cxx_name = "construct_unique"]
+        pub fn Message_ProgressRange_ctor() -> UniquePtr<Message_ProgressRange>;
 
         // Handles
         type HandleStandardType;
@@ -39,8 +39,8 @@ pub mod ffi {
         pub fn DynamicType(surface: &HandleGeomSurface) -> &HandleStandardType;
         pub fn type_name(handle: &HandleStandardType) -> String;
 
-        #[rust_name = "new_HandleGeomCurve_from_HandleGeom_TrimmedCurve"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn new_HandleGeomCurve_from_HandleGeom_TrimmedCurve(
             trimmed_curve_handle: &HandleGeomTrimmedCurve,
         ) -> UniquePtr<HandleGeomCurve>;
 
@@ -63,8 +63,8 @@ pub mod ffi {
         // Collections
         type TopTools_ListOfShape;
 
-        #[rust_name = "new_list_of_shape"]
-        pub fn construct_unique() -> UniquePtr<TopTools_ListOfShape>;
+        #[cxx_name = "construct_unique"]
+        pub fn new_list_of_shape() -> UniquePtr<TopTools_ListOfShape>;
         pub fn shape_list_append_face(list: Pin<&mut TopTools_ListOfShape>, face: &TopoDS_Face);
 
         // Geometry
@@ -107,28 +107,28 @@ pub mod ffi {
         type gp_Pnt;
         type gp_Pnt2d;
 
-        #[rust_name = "new_point"]
-        pub fn construct_unique(x: f64, y: f64, z: f64) -> UniquePtr<gp_Pnt>;
+        #[cxx_name = "construct_unique"]
+        pub fn new_point(x: f64, y: f64, z: f64) -> UniquePtr<gp_Pnt>;
 
         pub fn X(self: &gp_Pnt) -> f64;
         pub fn Y(self: &gp_Pnt) -> f64;
         pub fn Z(self: &gp_Pnt) -> f64;
         pub fn Distance(self: &gp_Pnt, other: &gp_Pnt) -> f64;
 
-        #[rust_name = "new_point_2d"]
-        pub fn construct_unique(x: f64, y: f64) -> UniquePtr<gp_Pnt2d>;
+        #[cxx_name = "construct_unique"]
+        pub fn new_point_2d(x: f64, y: f64) -> UniquePtr<gp_Pnt2d>;
 
         type gp_Vec;
 
-        #[rust_name = "new_vec"]
-        pub fn construct_unique(x: f64, y: f64, z: f64) -> UniquePtr<gp_Vec>;
+        #[cxx_name = "construct_unique"]
+        pub fn new_vec(x: f64, y: f64, z: f64) -> UniquePtr<gp_Vec>;
 
         // Segments
         type GC_MakeSegment;
         type GCE2d_MakeSegment;
 
-        #[rust_name = "GC_MakeSegment_point_point"]
-        pub fn construct_unique(p1: &gp_Pnt, p2: &gp_Pnt) -> UniquePtr<GC_MakeSegment>;
+        #[cxx_name = "construct_unique"]
+        pub fn GC_MakeSegment_point_point(p1: &gp_Pnt, p2: &gp_Pnt) -> UniquePtr<GC_MakeSegment>;
 
         pub fn GC_MakeSegment_Value(arc: &GC_MakeSegment) -> UniquePtr<HandleGeomTrimmedCurve>;
         pub fn GCE2d_MakeSegment_point_point(
@@ -139,8 +139,8 @@ pub mod ffi {
         // Arcs
         type GC_MakeArcOfCircle;
 
-        #[rust_name = "GC_MakeArcOfCircle_point_point_point"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn GC_MakeArcOfCircle_point_point_point(
             p1: &gp_Pnt,
             p2: &gp_Pnt,
             p3: &gp_Pnt,
@@ -161,20 +161,20 @@ pub mod ffi {
         pub fn TopoDS_cast_to_edge(shape: &TopoDS_Shape) -> &TopoDS_Edge;
         pub fn TopoDS_cast_to_face(shape: &TopoDS_Shape) -> &TopoDS_Face;
 
-        #[rust_name = "TopoDS_Shape_to_owned"]
-        pub fn construct_unique(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
+        #[cxx_name = "construct_unique"]
+        pub fn TopoDS_Shape_to_owned(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
 
-        #[rust_name = "TopoDS_Vertex_to_owned"]
-        pub fn construct_unique(shape: &TopoDS_Vertex) -> UniquePtr<TopoDS_Vertex>;
+        #[cxx_name = "construct_unique"]
+        pub fn TopoDS_Vertex_to_owned(shape: &TopoDS_Vertex) -> UniquePtr<TopoDS_Vertex>;
 
-        #[rust_name = "TopoDS_Wire_to_owned"]
-        pub fn construct_unique(shape: &TopoDS_Wire) -> UniquePtr<TopoDS_Wire>;
+        #[cxx_name = "construct_unique"]
+        pub fn TopoDS_Wire_to_owned(shape: &TopoDS_Wire) -> UniquePtr<TopoDS_Wire>;
 
-        #[rust_name = "TopoDS_Edge_to_owned"]
-        pub fn construct_unique(shape: &TopoDS_Edge) -> UniquePtr<TopoDS_Edge>;
+        #[cxx_name = "construct_unique"]
+        pub fn TopoDS_Edge_to_owned(shape: &TopoDS_Edge) -> UniquePtr<TopoDS_Edge>;
 
-        #[rust_name = "TopoDS_Face_to_owned"]
-        pub fn construct_unique(shape: &TopoDS_Face) -> UniquePtr<TopoDS_Face>;
+        #[cxx_name = "construct_unique"]
+        pub fn TopoDS_Face_to_owned(shape: &TopoDS_Face) -> UniquePtr<TopoDS_Face>;
 
         pub fn IsNull(self: &TopoDS_Shape) -> bool;
         pub fn IsEqual(self: &TopoDS_Shape, other: &TopoDS_Shape) -> bool;
@@ -188,11 +188,11 @@ pub mod ffi {
         type BRep_Builder;
         type TopoDS_Builder;
 
-        #[rust_name = "TopoDS_Compound_ctor"]
-        pub fn construct_unique() -> UniquePtr<TopoDS_Compound>;
+        #[cxx_name = "construct_unique"]
+        pub fn TopoDS_Compound_ctor() -> UniquePtr<TopoDS_Compound>;
 
-        #[rust_name = "BRep_Builder_ctor"]
-        pub fn construct_unique() -> UniquePtr<BRep_Builder>;
+        #[cxx_name = "construct_unique"]
+        pub fn BRep_Builder_ctor() -> UniquePtr<BRep_Builder>;
 
         pub fn BRep_Builder_upcast_to_topods_builder(builder: &BRep_Builder) -> &TopoDS_Builder;
         pub fn MakeCompound(self: &TopoDS_Builder, compound: Pin<&mut TopoDS_Compound>);
@@ -202,13 +202,13 @@ pub mod ffi {
         type BRepBuilderAPI_MakeEdge;
         type TopoDS_Vertex;
 
-        #[rust_name = "BRepBuilderAPI_MakeEdge_HandleGeomCurve"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepBuilderAPI_MakeEdge_HandleGeomCurve(
             geom_curve_handle: &HandleGeomCurve,
         ) -> UniquePtr<BRepBuilderAPI_MakeEdge>;
 
-        #[rust_name = "BRepBuilderAPI_MakeEdge_CurveSurface2d"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepBuilderAPI_MakeEdge_CurveSurface2d(
             curve_handle: &HandleGeom2d_Curve,
             surface_handle: &HandleGeomSurface,
         ) -> UniquePtr<BRepBuilderAPI_MakeEdge>;
@@ -220,17 +220,17 @@ pub mod ffi {
 
         type BRepBuilderAPI_MakeWire;
 
-        #[rust_name = "BRepBuilderAPI_MakeWire_ctor"]
-        pub fn construct_unique() -> UniquePtr<BRepBuilderAPI_MakeWire>;
+        #[cxx_name = "construct_unique"]
+        pub fn BRepBuilderAPI_MakeWire_ctor() -> UniquePtr<BRepBuilderAPI_MakeWire>;
 
-        #[rust_name = "BRepBuilderAPI_MakeWire_edge_edge"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepBuilderAPI_MakeWire_edge_edge(
             edge_1: &TopoDS_Edge,
             edge_2: &TopoDS_Edge,
         ) -> UniquePtr<BRepBuilderAPI_MakeWire>;
 
-        #[rust_name = "BRepBuilderAPI_MakeWire_edge_edge_edge"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepBuilderAPI_MakeWire_edge_edge_edge(
             edge_1: &TopoDS_Edge,
             edge_2: &TopoDS_Edge,
             edge_3: &TopoDS_Edge,
@@ -243,8 +243,8 @@ pub mod ffi {
 
         type BRepBuilderAPI_MakeFace;
 
-        #[rust_name = "BRepBuilderAPI_MakeFace_wire"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepBuilderAPI_MakeFace_wire(
             wire: &TopoDS_Wire,
             only_plane: bool,
         ) -> UniquePtr<BRepBuilderAPI_MakeFace>;
@@ -256,8 +256,8 @@ pub mod ffi {
         // Primitives
         type BRepPrimAPI_MakePrism;
 
-        #[rust_name = "BRepPrimAPI_MakePrism_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepPrimAPI_MakePrism_ctor(
             shape: &TopoDS_Shape,
             vec: &gp_Vec,
             copy: bool,
@@ -270,8 +270,8 @@ pub mod ffi {
 
         type BRepPrimAPI_MakeRevol;
 
-        #[rust_name = "BRepPrimAPI_MakeRevol_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepPrimAPI_MakeRevol_ctor(
             shape: &TopoDS_Shape,
             axis: &gp_Ax1,
             angle: f64,
@@ -290,8 +290,8 @@ pub mod ffi {
 
         type BRepPrimAPI_MakeCylinder;
 
-        #[rust_name = "BRepPrimAPI_MakeCylinder_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepPrimAPI_MakeCylinder_ctor(
             coord_system: &gp_Ax2,
             radius: f64,
             height: f64,
@@ -303,8 +303,8 @@ pub mod ffi {
 
         type BRepPrimAPI_MakeBox;
 
-        #[rust_name = "BRepPrimAPI_MakeBox_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepPrimAPI_MakeBox_ctor(
             point: &gp_Pnt,
             dx: f64,
             dy: f64,
@@ -317,8 +317,8 @@ pub mod ffi {
 
         type BRepPrimAPI_MakeSphere;
 
-        #[rust_name = "BRepPrimAPI_MakeSphere_ctor"]
-        pub fn construct_unique(r: f64) -> UniquePtr<BRepPrimAPI_MakeSphere>;
+        #[cxx_name = "construct_unique"]
+        pub fn BRepPrimAPI_MakeSphere_ctor(r: f64) -> UniquePtr<BRepPrimAPI_MakeSphere>;
 
         pub fn Shape(self: Pin<&mut BRepPrimAPI_MakeSphere>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepPrimAPI_MakeSphere>, progress: &Message_ProgressRange);
@@ -330,8 +330,10 @@ pub mod ffi {
         // Fillets
         type BRepFilletAPI_MakeFillet;
 
-        #[rust_name = "BRepFilletAPI_MakeFillet_ctor"]
-        pub fn construct_unique(shape: &TopoDS_Shape) -> UniquePtr<BRepFilletAPI_MakeFillet>;
+        #[cxx_name = "construct_unique"]
+        pub fn BRepFilletAPI_MakeFillet_ctor(
+            shape: &TopoDS_Shape,
+        ) -> UniquePtr<BRepFilletAPI_MakeFillet>;
 
         #[rust_name = "add_edge"]
         pub fn Add(self: Pin<&mut BRepFilletAPI_MakeFillet>, radius: f64, edge: &TopoDS_Edge);
@@ -342,8 +344,10 @@ pub mod ffi {
         // Chamfers
         type BRepFilletAPI_MakeChamfer;
 
-        #[rust_name = "BRepFilletAPI_MakeChamfer_ctor"]
-        pub fn construct_unique(shape: &TopoDS_Shape) -> UniquePtr<BRepFilletAPI_MakeChamfer>;
+        #[cxx_name = "construct_unique"]
+        pub fn BRepFilletAPI_MakeChamfer_ctor(
+            shape: &TopoDS_Shape,
+        ) -> UniquePtr<BRepFilletAPI_MakeChamfer>;
 
         #[rust_name = "add_edge"]
         pub fn Add(self: Pin<&mut BRepFilletAPI_MakeChamfer>, distance: f64, edge: &TopoDS_Edge);
@@ -354,8 +358,8 @@ pub mod ffi {
         // Solids
         type BRepOffsetAPI_MakeThickSolid;
 
-        #[rust_name = "BRepOffsetAPI_MakeThickSolid_ctor"]
-        pub fn construct_unique() -> UniquePtr<BRepOffsetAPI_MakeThickSolid>;
+        #[cxx_name = "construct_unique"]
+        pub fn BRepOffsetAPI_MakeThickSolid_ctor() -> UniquePtr<BRepOffsetAPI_MakeThickSolid>;
 
         pub fn MakeThickSolidByJoin(
             make_thick_solid: Pin<&mut BRepOffsetAPI_MakeThickSolid>,
@@ -374,8 +378,10 @@ pub mod ffi {
         // Lofting
         type BRepOffsetAPI_ThruSections;
 
-        #[rust_name = "BRepOffsetAPI_ThruSections_ctor"]
-        pub fn construct_unique(is_solid: bool) -> UniquePtr<BRepOffsetAPI_ThruSections>;
+        #[cxx_name = "construct_unique"]
+        pub fn BRepOffsetAPI_ThruSections_ctor(
+            is_solid: bool,
+        ) -> UniquePtr<BRepOffsetAPI_ThruSections>;
 
         pub fn AddWire(self: Pin<&mut BRepOffsetAPI_ThruSections>, wire: &TopoDS_Wire);
         pub fn CheckCompatibility(self: Pin<&mut BRepOffsetAPI_ThruSections>, check: bool);
@@ -386,8 +392,8 @@ pub mod ffi {
         // Boolean Operations
         type BRepAlgoAPI_Fuse;
 
-        #[rust_name = "BRepAlgoAPI_Fuse_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepAlgoAPI_Fuse_ctor(
             shape_1: &TopoDS_Shape,
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Fuse>;
@@ -398,8 +404,8 @@ pub mod ffi {
 
         type BRepAlgoAPI_Cut;
 
-        #[rust_name = "BRepAlgoAPI_Cut_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepAlgoAPI_Cut_ctor(
             shape_1: &TopoDS_Shape,
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Cut>;
@@ -410,8 +416,8 @@ pub mod ffi {
 
         type BRepAlgoAPI_Common;
 
-        #[rust_name = "BRepAlgoAPI_Common_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepAlgoAPI_Common_ctor(
             shape_1: &TopoDS_Shape,
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Common>;
@@ -422,8 +428,8 @@ pub mod ffi {
 
         type BRepAlgoAPI_Section;
 
-        #[rust_name = "BRepAlgoAPI_Section_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepAlgoAPI_Section_ctor(
             shape_1: &TopoDS_Shape,
             shape_2: &TopoDS_Shape,
         ) -> UniquePtr<BRepAlgoAPI_Section>;
@@ -444,23 +450,23 @@ pub mod ffi {
         pub fn gp_OZ() -> &'static gp_Ax1;
         pub fn gp_DZ() -> &'static gp_Dir;
 
-        #[rust_name = "gp_Ax2_ctor"]
-        pub fn construct_unique(origin: &gp_Pnt, main_dir: &gp_Dir) -> UniquePtr<gp_Ax2>;
+        #[cxx_name = "construct_unique"]
+        pub fn gp_Ax2_ctor(origin: &gp_Pnt, main_dir: &gp_Dir) -> UniquePtr<gp_Ax2>;
 
-        #[rust_name = "gp_Ax3_from_gp_Ax2"]
-        pub fn construct_unique(axis: &gp_Ax2) -> UniquePtr<gp_Ax3>;
+        #[cxx_name = "construct_unique"]
+        pub fn gp_Ax3_from_gp_Ax2(axis: &gp_Ax2) -> UniquePtr<gp_Ax3>;
 
-        #[rust_name = "gp_Dir2d_ctor"]
-        pub fn construct_unique(x: f64, y: f64) -> UniquePtr<gp_Dir2d>;
+        #[cxx_name = "construct_unique"]
+        pub fn gp_Dir2d_ctor(x: f64, y: f64) -> UniquePtr<gp_Dir2d>;
 
-        #[rust_name = "gp_Ax2d_ctor"]
-        pub fn construct_unique(point: &gp_Pnt2d, dir: &gp_Dir2d) -> UniquePtr<gp_Ax2d>;
+        #[cxx_name = "construct_unique"]
+        pub fn gp_Ax2d_ctor(point: &gp_Pnt2d, dir: &gp_Dir2d) -> UniquePtr<gp_Ax2d>;
 
         // Transforms
         type gp_Trsf;
 
-        #[rust_name = "new_transform"]
-        pub fn construct_unique() -> UniquePtr<gp_Trsf>;
+        #[cxx_name = "construct_unique"]
+        pub fn new_transform() -> UniquePtr<gp_Trsf>;
 
         #[rust_name = "set_mirror_axis"]
         pub fn SetMirror(self: Pin<&mut gp_Trsf>, axis: &gp_Ax1);
@@ -470,8 +476,8 @@ pub mod ffi {
 
         type BRepBuilderAPI_Transform;
 
-        #[rust_name = "BRepBuilderAPI_Transform_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepBuilderAPI_Transform_ctor(
             shape: &TopoDS_Shape,
             transform: &gp_Trsf,
             copy: bool,
@@ -485,8 +491,8 @@ pub mod ffi {
         type TopExp_Explorer;
         type TopAbs_ShapeEnum;
 
-        #[rust_name = "TopExp_Explorer_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn TopExp_Explorer_ctor(
             shape: &TopoDS_Shape,
             to_find: TopAbs_ShapeEnum,
         ) -> UniquePtr<TopExp_Explorer>;
@@ -507,8 +513,8 @@ pub mod ffi {
         // Data export
         type StlAPI_Writer;
 
-        #[rust_name = "StlAPI_Writer_ctor"]
-        pub fn construct_unique() -> UniquePtr<StlAPI_Writer>;
+        #[cxx_name = "construct_unique"]
+        pub fn StlAPI_Writer_ctor() -> UniquePtr<StlAPI_Writer>;
 
         // pub fn Write(self: Pin<&mut StlAPI_Writer>, shape: &TopoDS_Shape, filename: &c_char) -> bool;
         pub fn write_stl(
@@ -520,8 +526,8 @@ pub mod ffi {
         // Triangulation
         type BRepMesh_IncrementalMesh;
 
-        #[rust_name = "BRepMesh_IncrementalMesh_ctor"]
-        pub fn construct_unique(
+        #[cxx_name = "construct_unique"]
+        pub fn BRepMesh_IncrementalMesh_ctor(
             shape: &TopoDS_Shape,
             deflection: f64,
         ) -> UniquePtr<BRepMesh_IncrementalMesh>;


### PR DESCRIPTION
Closes #15

For now I kept the function names the same, but when we address #17 we can clean up the naming conventions.

@DSchroer what do you think about also using this template for the `*_to_owned()` functions?