### PR TITLE
Add dynamic linking support for faster builds

### DIFF
--- a/crates/opencascade-sys/Cargo.toml
+++ b/crates/opencascade-sys/Cargo.toml
@@ -46,6 +46,9 @@ exclude = [
     "OCCT/tools/*",
 ]
 
+[features]
+dynamic = []
+
 [dependencies]
 cxx = "1"
 

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -1,7 +1,7 @@
 const LIBS: [&str; 18] = [
     "TKMath",
-    "TKMath",
     "TKernel",
+    "TKFeat",
     "TKGeomBase",
     "TKG2d",
     "TKG3d",

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -1,4 +1,4 @@
-const LIBS: [&'static str; 18] = [
+const LIBS: [&str; 18] = [
     "TKMath",
     "TKMath",
     "TKernel",

--- a/crates/opencascade-sys/src/main.rs
+++ b/crates/opencascade-sys/src/main.rs
@@ -1,0 +1,6 @@
+use opencascade_sys::ffi::new_point;
+
+fn main() {
+    let point = new_point(0.0, 0.0, 0.0);
+    println!("x: {}, y: {}, z: {}", point.X(), point.Y(), point.Z());
+}


### PR DESCRIPTION
Working out of multiple repositories, the `opencascade-sys` library tends to be a major bottleneck for building. Added a `dynamic` feature that uses system libs rather than building opencascade from scratch each time. 