### PR TITLE
Chamfer support to primitives

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -257,6 +257,26 @@ inline std::unique_ptr<TopoDS_Shape> ExplorerCurrentShape(const TopExp_Explorer 
   return std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape(explorer.Current()));
 }
 
+inline std::unique_ptr<TopoDS_Vertex> TopExp_FirstVertex(const TopoDS_Edge &edge) {
+  return std::unique_ptr<TopoDS_Vertex>(new TopoDS_Vertex(TopExp::FirstVertex(edge)));
+}
+
+inline std::unique_ptr<TopoDS_Vertex> TopExp_LastVertex(const TopoDS_Edge &edge) {
+  return std::unique_ptr<TopoDS_Vertex>(new TopoDS_Vertex(TopExp::LastVertex(edge)));
+}
+
+inline void TopExp_EdgeVertices(const TopoDS_Edge &edge, TopoDS_Vertex &vertex1, TopoDS_Vertex &vertex2) {
+  return TopExp::Vertices(edge, vertex1, vertex2);
+}
+
+inline void TopExp_WireVertices(const TopoDS_Wire &wire, TopoDS_Vertex &vertex1, TopoDS_Vertex &vertex2) {
+  return TopExp::Vertices(wire, vertex1, vertex2);
+}
+
+inline bool TopExp_CommonVertex(const TopoDS_Edge &edge1, const TopoDS_Edge &edge2, TopoDS_Vertex &vertex) {
+  return TopExp::CommonVertex(edge1, edge2, vertex);
+}
+
 inline std::unique_ptr<TopoDS_Face> BRepIntCurveSurface_Inter_face(const BRepIntCurveSurface_Inter &intersector) {
   return std::unique_ptr<TopoDS_Face>(new TopoDS_Face(intersector.Face()));
 }
@@ -355,6 +375,11 @@ inline void map_shapes(const TopoDS_Shape &S, const TopAbs_ShapeEnum T, TopTools
 inline void map_shapes_and_ancestors(const TopoDS_Shape &S, const TopAbs_ShapeEnum TS, const TopAbs_ShapeEnum TA,
                                      TopTools_IndexedDataMapOfShapeListOfShape &M) {
   TopExp::MapShapesAndAncestors(S, TS, TA, M);
+}
+
+inline void map_shapes_and_unique_ancestors(const TopoDS_Shape &S, const TopAbs_ShapeEnum TS, const TopAbs_ShapeEnum TA,
+                                            TopTools_IndexedDataMapOfShapeListOfShape &M) {
+  TopExp::MapShapesAndUniqueAncestors(S, TS, TA, M);
 }
 
 inline std::unique_ptr<gp_Dir> TColgp_Array1OfDir_Value(const TColgp_Array1OfDir &array, Standard_Integer index) {

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -316,6 +316,23 @@ inline std::unique_ptr<TopoDS_Edge> BRepFilletAPI_MakeFillet2d_add_fillet(BRepFi
   return std::unique_ptr<TopoDS_Edge>(new TopoDS_Edge(make_fillet.AddFillet(vertex, radius)));
 }
 
+// Chamfers
+inline std::unique_ptr<TopoDS_Edge> BRepFilletAPI_MakeFillet2d_add_chamfer(BRepFilletAPI_MakeFillet2d &make_fillet,
+                                                                          const TopoDS_Edge &edge1,
+                                                                          const TopoDS_Edge &edge2,
+                                                                          const Standard_Real dist1,
+                                                                          const Standard_Real dist2) {
+  return std::unique_ptr<TopoDS_Edge>(new TopoDS_Edge(make_fillet.AddChamfer(edge1, edge2, dist1, dist2)));
+}
+
+inline std::unique_ptr<TopoDS_Edge> BRepFilletAPI_MakeFillet2d_add_chamfer_angle(BRepFilletAPI_MakeFillet2d &make_fillet,
+                                                                          const TopoDS_Edge &edge,
+                                                                          const TopoDS_Vertex &vertex,
+                                                                          const Standard_Real dist,
+                                                                          const Standard_Real angle) {
+  return std::unique_ptr<TopoDS_Edge>(new TopoDS_Edge(make_fillet.AddChamfer(edge, vertex, dist, angle)));
+}
+
 // BRepTools
 inline std::unique_ptr<TopoDS_Wire> outer_wire(const TopoDS_Face &face) {
   return std::unique_ptr<TopoDS_Wire>(new TopoDS_Wire(BRepTools::OuterWire(face)));

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -352,6 +352,11 @@ inline void map_shapes(const TopoDS_Shape &S, const TopAbs_ShapeEnum T, TopTools
   TopExp::MapShapes(S, T, M);
 }
 
+inline void map_shapes_and_ancestors(const TopoDS_Shape &S, const TopAbs_ShapeEnum TS, const TopAbs_ShapeEnum TA,
+                                     TopTools_IndexedDataMapOfShapeListOfShape &M) {
+  TopExp::MapShapesAndAncestors(S, TS, TA, M);
+}
+
 inline std::unique_ptr<gp_Dir> TColgp_Array1OfDir_Value(const TColgp_Array1OfDir &array, Standard_Integer index) {
   return std::unique_ptr<gp_Dir>(new gp_Dir(array.Value(index)));
 }

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -317,19 +317,16 @@ inline std::unique_ptr<TopoDS_Edge> BRepFilletAPI_MakeFillet2d_add_fillet(BRepFi
 }
 
 // Chamfers
-inline std::unique_ptr<TopoDS_Edge> BRepFilletAPI_MakeFillet2d_add_chamfer(BRepFilletAPI_MakeFillet2d &make_fillet,
-                                                                          const TopoDS_Edge &edge1,
-                                                                          const TopoDS_Edge &edge2,
-                                                                          const Standard_Real dist1,
-                                                                          const Standard_Real dist2) {
+inline std::unique_ptr<TopoDS_Edge>
+BRepFilletAPI_MakeFillet2d_add_chamfer(BRepFilletAPI_MakeFillet2d &make_fillet, const TopoDS_Edge &edge1,
+                                       const TopoDS_Edge &edge2, const Standard_Real dist1, const Standard_Real dist2) {
   return std::unique_ptr<TopoDS_Edge>(new TopoDS_Edge(make_fillet.AddChamfer(edge1, edge2, dist1, dist2)));
 }
 
-inline std::unique_ptr<TopoDS_Edge> BRepFilletAPI_MakeFillet2d_add_chamfer_angle(BRepFilletAPI_MakeFillet2d &make_fillet,
-                                                                          const TopoDS_Edge &edge,
-                                                                          const TopoDS_Vertex &vertex,
-                                                                          const Standard_Real dist,
-                                                                          const Standard_Real angle) {
+inline std::unique_ptr<TopoDS_Edge>
+BRepFilletAPI_MakeFillet2d_add_chamfer_angle(BRepFilletAPI_MakeFillet2d &make_fillet, const TopoDS_Edge &edge,
+                                             const TopoDS_Vertex &vertex, const Standard_Real dist,
+                                             const Standard_Real angle) {
   return std::unique_ptr<TopoDS_Edge>(new TopoDS_Edge(make_fillet.AddChamfer(edge, vertex, dist, angle)));
 }
 

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -1,4 +1,5 @@
 #include "rust/cxx.h"
+#include <BOPAlgo_GlueEnum.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepAlgoAPI_Common.hxx>
 #include <BRepAlgoAPI_Cut.hxx>

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -466,6 +466,20 @@ pub mod ffi {
             vertex: &TopoDS_Vertex,
             radius: f64,
         ) -> UniquePtr<TopoDS_Edge>;
+        pub fn BRepFilletAPI_MakeFillet2d_add_chamfer(
+            make_fillet: Pin<&mut BRepFilletAPI_MakeFillet2d>,
+            edge1: &TopoDS_Edge,
+            edge2: &TopoDS_Edge,
+            distance1: f64,
+            distance2: f64,
+        ) -> UniquePtr<TopoDS_Edge>;
+        pub fn BRepFilletAPI_MakeFillet2d_add_chamfer_angle(
+            make_fillet: Pin<&mut BRepFilletAPI_MakeFillet2d>,
+            edge: &TopoDS_Edge,
+            vertex: &TopoDS_Vertex,
+            distance: f64,
+            angle: f64,
+        ) -> UniquePtr<TopoDS_Edge>;
         pub fn Build(self: Pin<&mut BRepFilletAPI_MakeFillet2d>, progress: &Message_ProgressRange);
         pub fn Shape(self: Pin<&mut BRepFilletAPI_MakeFillet2d>) -> &TopoDS_Shape;
         pub fn IsDone(self: &BRepFilletAPI_MakeFillet2d) -> bool;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -134,6 +134,12 @@ pub mod ffi {
             child_type: TopAbs_ShapeEnum,
             shape_data_map: Pin<&mut TopTools_IndexedDataMapOfShapeListOfShape>,
         );
+        pub fn map_shapes_and_unique_ancestors(
+            shape: &TopoDS_Shape,
+            parent_type: TopAbs_ShapeEnum,
+            child_type: TopAbs_ShapeEnum,
+            shape_data_map: Pin<&mut TopTools_IndexedDataMapOfShapeListOfShape>,
+        );
 
         type TColgp_Array1OfDir;
         #[cxx_name = "construct_unique"]
@@ -749,6 +755,24 @@ pub mod ffi {
         pub fn Next(self: Pin<&mut TopExp_Explorer>);
         pub fn ExplorerCurrentShape(explorer: &TopExp_Explorer) -> UniquePtr<TopoDS_Shape>;
         pub fn Current(self: &TopExp_Explorer) -> &TopoDS_Shape;
+
+        pub fn TopExp_FirstVertex(edge: &TopoDS_Edge) -> UniquePtr<TopoDS_Vertex>;
+        pub fn TopExp_LastVertex(edge: &TopoDS_Edge) -> UniquePtr<TopoDS_Vertex>;
+        pub fn TopExp_EdgeVertices(
+            edge: &TopoDS_Edge,
+            vertex_first: Pin<&mut TopoDS_Vertex>,
+            vertex_last: Pin<&mut TopoDS_Vertex>,
+        );
+        pub fn TopExp_WireVertices(
+            wire: &TopoDS_Wire,
+            vertex_first: Pin<&mut TopoDS_Vertex>,
+            vertex_last: Pin<&mut TopoDS_Vertex>,
+        );
+        pub fn TopExp_CommonVertex(
+            edge_1: &TopoDS_Edge,
+            edge_2: &TopoDS_Edge,
+            vertex: Pin<&mut TopoDS_Vertex>,
+        ) -> bool;
 
         pub fn BRep_Tool_Surface(face: &TopoDS_Face) -> UniquePtr<HandleGeomSurface>;
         pub fn BRep_Tool_Curve(

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -32,6 +32,14 @@ pub mod ffi {
         IFSelect_RetStop,
     }
 
+    #[derive(Debug)]
+    #[repr(u32)]
+    pub enum BOPAlgo_GlueEnum {
+        BOPAlgo_GlueOff,
+        BOPAlgo_GlueShift,
+        BOPAlgo_GlueFull,
+    }
+
     unsafe extern "C++" {
         // https://github.com/dtolnay/cxx/issues/280
 
@@ -616,6 +624,7 @@ pub mod ffi {
 
         // Boolean Operations
         type BRepAlgoAPI_Fuse;
+        type BOPAlgo_GlueEnum;
 
         #[cxx_name = "construct_unique"]
         pub fn BRepAlgoAPI_Fuse_ctor(
@@ -627,6 +636,7 @@ pub mod ffi {
         pub fn Build(self: Pin<&mut BRepAlgoAPI_Fuse>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Fuse) -> bool;
         pub fn SectionEdges<'a>(self: Pin<&'a mut BRepAlgoAPI_Fuse>) -> &'a TopTools_ListOfShape;
+        pub fn SetGlue(self: Pin<&mut BRepAlgoAPI_Fuse>, glue: BOPAlgo_GlueEnum);
 
         type BRepAlgoAPI_Cut;
 

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -123,17 +123,17 @@ pub mod ffi {
             self: &TopTools_IndexedDataMapOfShapeListOfShape,
             index: i32,
         ) -> &TopoDS_Shape;
-        pub fn FindFromIndex<'a>(
-            self: &'a TopTools_IndexedDataMapOfShapeListOfShape,
+        pub fn FindFromIndex(
+            self: &TopTools_IndexedDataMapOfShapeListOfShape,
             index: i32,
-        ) -> &'a TopTools_ListOfShape;
+        ) -> &TopTools_ListOfShape;
         pub fn FindIndex(
             self: &TopTools_IndexedDataMapOfShapeListOfShape,
             shape: &TopoDS_Shape,
         ) -> i32;
         pub fn FindFromKey<'a>(
             self: &'a TopTools_IndexedDataMapOfShapeListOfShape,
-            shape: &TopoDS_Shape,
+            shape: &'a TopoDS_Shape,
         ) -> &'a TopTools_ListOfShape;
 
         pub fn map_shapes_and_ancestors(
@@ -635,7 +635,7 @@ pub mod ffi {
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Fuse>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepAlgoAPI_Fuse>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Fuse) -> bool;
-        pub fn SectionEdges<'a>(self: Pin<&'a mut BRepAlgoAPI_Fuse>) -> &'a TopTools_ListOfShape;
+        pub fn SectionEdges(self: Pin<&mut BRepAlgoAPI_Fuse>) -> &TopTools_ListOfShape;
         pub fn SetGlue(self: Pin<&mut BRepAlgoAPI_Fuse>, glue: BOPAlgo_GlueEnum);
 
         type BRepAlgoAPI_Cut;
@@ -653,7 +653,7 @@ pub mod ffi {
             self: Pin<&'a mut BRepAlgoAPI_Cut>,
             shape: &'a TopoDS_Shape,
         ) -> &'a TopTools_ListOfShape;
-        pub fn SectionEdges<'a>(self: Pin<&'a mut BRepAlgoAPI_Cut>) -> &'a TopTools_ListOfShape;
+        pub fn SectionEdges(self: Pin<&mut BRepAlgoAPI_Cut>) -> &TopTools_ListOfShape;
 
         type BRepAlgoAPI_Common;
 

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -105,6 +105,36 @@ pub mod ffi {
             shape_map: Pin<&mut TopTools_IndexedMapOfShape>,
         );
 
+        type TopTools_IndexedDataMapOfShapeListOfShape;
+
+        #[cxx_name = "construct_unique"]
+        pub fn new_indexed_data_map_of_shape_list_of_shape(
+        ) -> UniquePtr<TopTools_IndexedDataMapOfShapeListOfShape>;
+        pub fn Extent(self: &TopTools_IndexedDataMapOfShapeListOfShape) -> i32;
+        pub fn FindKey(
+            self: &TopTools_IndexedDataMapOfShapeListOfShape,
+            index: i32,
+        ) -> &TopoDS_Shape;
+        pub fn FindFromIndex<'a>(
+            self: &'a TopTools_IndexedDataMapOfShapeListOfShape,
+            index: i32,
+        ) -> &'a TopTools_ListOfShape;
+        pub fn FindIndex(
+            self: &TopTools_IndexedDataMapOfShapeListOfShape,
+            shape: &TopoDS_Shape,
+        ) -> i32;
+        pub fn FindFromKey<'a>(
+            self: &'a TopTools_IndexedDataMapOfShapeListOfShape,
+            shape: &TopoDS_Shape,
+        ) -> &'a TopTools_ListOfShape;
+
+        pub fn map_shapes_and_ancestors(
+            shape: &TopoDS_Shape,
+            parent_type: TopAbs_ShapeEnum,
+            child_type: TopAbs_ShapeEnum,
+            shape_data_map: Pin<&mut TopTools_IndexedDataMapOfShapeListOfShape>,
+        );
+
         type TColgp_Array1OfDir;
         #[cxx_name = "construct_unique"]
         pub fn TColgp_Array1OfDir_ctor(
@@ -590,6 +620,7 @@ pub mod ffi {
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Fuse>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepAlgoAPI_Fuse>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Fuse) -> bool;
+        pub fn SectionEdges<'a>(self: Pin<&'a mut BRepAlgoAPI_Fuse>) -> &'a TopTools_ListOfShape;
 
         type BRepAlgoAPI_Cut;
 

--- a/crates/opencascade/examples/chamfer.rs
+++ b/crates/opencascade/examples/chamfer.rs
@@ -1,6 +1,6 @@
 use glam::dvec3;
 use opencascade::{
-    primitives::{Direction, Edge, Face, Solid},
+    primitives::{Direction, Face, Solid},
     workplane::Workplane,
 };
 
@@ -15,11 +15,13 @@ pub fn main() {
 
     let chamfered_box = Solid::loft([&base, &top].into_iter());
 
-    let handle = Workplane::xy().rect(5.0, 5.0);
+    // insert the workplane into the chamfered box area so union returns edges
+    let handle = Workplane::xy().translated(dvec3(0.0, 0.0, 0.1)).rect(5.0, 5.0);
     let handle_face = Face::from_wire(&handle);
 
     let handle_body = handle_face.extrude(dvec3(0.0, 0.0, -10.0));
-    let (mut chamfered_shape, _fuse_edges) = chamfered_box.union(&handle_body);
+    let (mut chamfered_shape, fuse_edges) = chamfered_box.union(&handle_body);
+    chamfered_shape.chamfer_edges(0.5, &fuse_edges);
 
     // chamfer the top of the protrusion
     let top_edges: Vec<_> = chamfered_shape
@@ -29,18 +31,6 @@ pub fn main() {
         .edges() // Get all the edges of this face
         .collect();
     chamfered_shape.chamfer_edges(1.0, &top_edges);
-
-    // TODO figure out why the fuse does not return edges
-    // chamfer the handle join edges
-    // let handle_join_edges = chamfered_shape
-    //     .edges()
-    //     .filter(|edge| {
-    //         let start = edge.start_point();
-    //         let end = edge.end_point();
-    //         (start.x.abs() == 2.5 && start.z == 0.0) || (end.y.abs() == 2.5 && end.z == 0.0)
-    //     })
-    //     .collect::<Vec<Edge>>();
-    // chamfered_shape.chamfer_edges(0.5, &fuse_edges);
 
     // can also just chamfer the whole shape
     // chamfered_shape.chamfer(0.5);

--- a/crates/opencascade/examples/chamfer.rs
+++ b/crates/opencascade/examples/chamfer.rs
@@ -1,6 +1,8 @@
 use glam::dvec3;
-use opencascade::primitives::{Edge, Face, ToAngle};
-use opencascade::{primitives::Solid, workplane::Workplane};
+use opencascade::{
+    primitives::{Edge, Face, Solid, ToAngle},
+    workplane::Workplane,
+};
 
 pub fn main() {
     let mut base = Workplane::xy().rect(10.0, 10.0);

--- a/crates/opencascade/examples/chamfer.rs
+++ b/crates/opencascade/examples/chamfer.rs
@@ -1,0 +1,15 @@
+use glam::dvec3;
+use opencascade::{primitives::Solid, workplane::Workplane};
+
+pub fn main() {
+    let mut base = Workplane::xy().rect(10.0, 10.0);
+    base.chamfer(1.0, Some(2.0));
+
+    let mut top = Workplane::xy().rect(10.0, 10.0);
+    top.chamfer_angle(2.0, 1.0);
+    top.translate(dvec3(0.0, 0.0, 10.0));
+
+    let chamfered_box = Solid::loft([&base, &top].into_iter());
+
+    chamfered_box.write_stl("chamfer.stl").unwrap();
+}

--- a/crates/opencascade/examples/chamfer.rs
+++ b/crates/opencascade/examples/chamfer.rs
@@ -13,13 +13,13 @@ pub fn main() {
     top.translate(dvec3(0.0, 0.0, 10.0));
     top.chamfer(1.0, None);
 
-    let chamfered_box = Solid::loft([&base, &top].into_iter());
+    let chamfered_box = Solid::loft([&base, &top].into_iter()).to_shape();
 
     // insert the workplane into the chamfered box area so union returns edges
     let handle = Workplane::xy().translated(dvec3(0.0, 0.0, 0.1)).rect(5.0, 5.0);
     let handle_face = Face::from_wire(&handle);
 
-    let handle_body = handle_face.extrude(dvec3(0.0, 0.0, -10.0));
+    let handle_body = handle_face.extrude(dvec3(0.0, 0.0, -10.1));
     let (mut chamfered_shape, fuse_edges) = chamfered_box.union(&handle_body);
     chamfered_shape.chamfer_edges(0.5, &fuse_edges);
 

--- a/crates/opencascade/examples/chamfer.rs
+++ b/crates/opencascade/examples/chamfer.rs
@@ -1,18 +1,17 @@
 use glam::dvec3;
 use opencascade::{
-    primitives::{Direction, Edge, Face, Solid, ToAngle},
+    primitives::{Direction, Edge, Face, Solid},
     workplane::Workplane,
 };
 
 pub fn main() {
+    // A tapering chamfer from bottom to top 2->1
     let mut base = Workplane::xy().rect(10.0, 10.0);
-    // asymmetric chamfer
-    base.chamfer(1.0, Some(2.0));
+    base.chamfer(2.0, None);
 
     let mut top = Workplane::xy().rect(10.0, 10.0);
-    // 45 degree chamfer - other angles will be asymmetric
-    top.chamfer_angle(2.0, 45.degrees());
     top.translate(dvec3(0.0, 0.0, 10.0));
+    top.chamfer(1.0, None);
 
     let chamfered_box = Solid::loft([&base, &top].into_iter());
 
@@ -31,6 +30,7 @@ pub fn main() {
         .collect();
     chamfered_shape.chamfer_edges(1.0, &top_edges);
 
+    // TODO figure out why the fuse does not return edges
     // chamfer the handle join edges
     // let handle_join_edges = chamfered_shape
     //     .edges()

--- a/crates/opencascade/examples/chamfer.rs
+++ b/crates/opencascade/examples/chamfer.rs
@@ -1,6 +1,6 @@
 use glam::dvec3;
 use opencascade::{
-    primitives::{Edge, Face, Solid, ToAngle},
+    primitives::{Direction, Edge, Face, Solid, ToAngle},
     workplane::Workplane,
 };
 
@@ -20,25 +20,27 @@ pub fn main() {
     let handle_face = Face::from_wire(&handle);
 
     let handle_body = handle_face.extrude(dvec3(0.0, 0.0, -10.0));
-    let mut chamfered_shape = chamfered_box.union(&handle_body);
+    let (mut chamfered_shape, _fuse_edges) = chamfered_box.union(&handle_body);
 
-    // chamfer the top of the protrusion by getting shape edges at z = -10.0
-    let top_edges = chamfered_shape
-        .edges()
-        .filter(|edge| edge.start_point().z == -10.0 && edge.end_point().z == -10.0)
-        .collect::<Vec<Edge>>();
+    // chamfer the top of the protrusion
+    let top_edges: Vec<_> = chamfered_shape
+        .faces()
+        .farthest(Direction::NegZ) // Get the face whose center of mass is the farthest in the negative Z direction
+        .expect("Should have a face on the bottom of the handle")
+        .edges() // Get all the edges of this face
+        .collect();
     chamfered_shape.chamfer_edges(1.0, &top_edges);
 
     // chamfer the handle join edges
-    let handle_join_edges = chamfered_shape
-        .edges()
-        .filter(|edge| {
-            let start = edge.start_point();
-            let end = edge.end_point();
-            (start.x.abs() == 2.5 && start.z == 0.0) || (end.y.abs() == 2.5 && end.z == 0.0)
-        })
-        .collect::<Vec<Edge>>();
-    chamfered_shape.chamfer_edges(0.5, &handle_join_edges);
+    // let handle_join_edges = chamfered_shape
+    //     .edges()
+    //     .filter(|edge| {
+    //         let start = edge.start_point();
+    //         let end = edge.end_point();
+    //         (start.x.abs() == 2.5 && start.z == 0.0) || (end.y.abs() == 2.5 && end.z == 0.0)
+    //     })
+    //     .collect::<Vec<Edge>>();
+    // chamfered_shape.chamfer_edges(0.5, &fuse_edges);
 
     // can also just chamfer the whole shape
     // chamfered_shape.chamfer(0.5);

--- a/crates/opencascade/examples/chamfer.rs
+++ b/crates/opencascade/examples/chamfer.rs
@@ -1,15 +1,45 @@
 use glam::dvec3;
+use opencascade::primitives::{Edge, Face, ToAngle};
 use opencascade::{primitives::Solid, workplane::Workplane};
 
 pub fn main() {
     let mut base = Workplane::xy().rect(10.0, 10.0);
+    // asymmetric chamfer
     base.chamfer(1.0, Some(2.0));
 
     let mut top = Workplane::xy().rect(10.0, 10.0);
-    top.chamfer_angle(2.0, 1.0);
+    // 45 degree chamfer - other angles will be asymmetric
+    top.chamfer_angle(2.0, 45.degrees());
     top.translate(dvec3(0.0, 0.0, 10.0));
 
     let chamfered_box = Solid::loft([&base, &top].into_iter());
 
-    chamfered_box.write_stl("chamfer.stl").unwrap();
+    let handle = Workplane::xy().rect(5.0, 5.0);
+    let handle_face = Face::from_wire(&handle);
+
+    let handle_body = handle_face.extrude(dvec3(0.0, 0.0, -10.0));
+    let mut chamfered_shape = chamfered_box.union(&handle_body);
+
+    // chamfer the top of the protrusion by getting shape edges at z = -10.0
+    let top_edges = chamfered_shape
+        .edges()
+        .filter(|edge| edge.start_point().z == -10.0 && edge.end_point().z == -10.0)
+        .collect::<Vec<Edge>>();
+    chamfered_shape.chamfer_edges(1.0, &top_edges);
+
+    // chamfer the handle join edges
+    let handle_join_edges = chamfered_shape
+        .edges()
+        .filter(|edge| {
+            let start = edge.start_point();
+            let end = edge.end_point();
+            (start.x.abs() == 2.5 && start.z == 0.0) || (end.y.abs() == 2.5 && end.z == 0.0)
+        })
+        .collect::<Vec<Edge>>();
+    chamfered_shape.chamfer_edges(0.5, &handle_join_edges);
+
+    // can also just chamfer the whole shape
+    // chamfered_shape.chamfer(0.5);
+
+    chamfered_shape.write_stl("chamfer.stl").unwrap();
 }

--- a/crates/opencascade/examples/chamfer.rs
+++ b/crates/opencascade/examples/chamfer.rs
@@ -7,11 +7,11 @@ use opencascade::{
 pub fn main() {
     // A tapering chamfer from bottom to top 2->1
     let mut base = Workplane::xy().rect(10.0, 10.0);
-    base.chamfer(2.0, None);
+    base.chamfer(2.0);
 
     let mut top = Workplane::xy().rect(10.0, 10.0);
     top.translate(dvec3(0.0, 0.0, 10.0));
-    top.chamfer(1.0, None);
+    top.chamfer(1.0);
 
     let chamfered_box = Solid::loft([&base, &top].into_iter()).to_shape();
 

--- a/crates/opencascade/examples/keycap.rs
+++ b/crates/opencascade/examples/keycap.rs
@@ -10,7 +10,7 @@ const KEYCAP_PITCH: f64 = 19.05;
 
 pub fn main() {
     let convex = false;
-    let keycap_unit_size_x = 1.0;
+    let keycap_unit_size_x = 2.0;
     let keycap_unit_size_y = 1.0;
     let height = 16.0;
     let angle = 13.0;
@@ -190,7 +190,7 @@ pub fn main() {
 
         let post = circle.extrude_to_face(&keycap, &temp_face);
 
-        keycap = keycap.union_shape(&post);
+        (keycap, _) = keycap.union_shape(&post);
     }
 
     for (x, y) in ribh_points {
@@ -198,7 +198,7 @@ pub fn main() {
 
         let rib = rect.extrude_to_face(&keycap, &temp_face);
 
-        keycap = keycap.union_shape(&rib);
+        (keycap, _) = keycap.union_shape(&rib);
     }
 
     for (x, y) in ribv_points {
@@ -206,7 +206,7 @@ pub fn main() {
 
         let rib = rect.extrude_to_face(&keycap, &temp_face);
 
-        keycap = keycap.union_shape(&rib);
+        (keycap, _) = keycap.union_shape(&rib);
     }
 
     // TODO(bschwind) - This should probably be done after every union...
@@ -232,7 +232,7 @@ pub fn main() {
         let (face_target, _) = faces.get(0).expect("We should have a face to extrude to");
         let post = circle.extrude_to_face(&keycap, face_target);
 
-        keycap = keycap.union_shape(&post);
+        (keycap, _) = keycap.union_shape(&post);
     }
 
     let r1 = Face::from_wire(&Workplane::xy().rect(4.15, 1.27));

--- a/crates/opencascade/examples/keycap.rs
+++ b/crates/opencascade/examples/keycap.rs
@@ -10,7 +10,7 @@ const KEYCAP_PITCH: f64 = 19.05;
 
 pub fn main() {
     let convex = false;
-    let keycap_unit_size_x = 2.0;
+    let keycap_unit_size_x = 1.0;
     let keycap_unit_size_y = 1.0;
     let height = 16.0;
     let angle = 13.0;

--- a/crates/opencascade/examples/keycap.rs
+++ b/crates/opencascade/examples/keycap.rs
@@ -244,7 +244,8 @@ pub fn main() {
         cross.set_global_translation(dvec3(x, y, 0.0));
         let cross = cross.extrude(dvec3(0.0, 0.0, 4.6));
 
-        let (subtracted, _) = keycap.subtract_shape(&cross);
+        let (mut subtracted, edges) = keycap.subtract_shape(&cross);
+        subtracted.chamfer_edges(0.2, &edges);
         keycap = subtracted;
     }
 

--- a/crates/opencascade/examples/rounded_chamfer.rs
+++ b/crates/opencascade/examples/rounded_chamfer.rs
@@ -1,0 +1,19 @@
+use glam::dvec3;
+use opencascade::{primitives::Direction, workplane::Workplane};
+
+// Demonstrates filleting a 2D profile, extruding it, then chamfering
+// the top edges, resulting in a nice, rounded chamfer.
+
+pub fn main() {
+    let mut base = Workplane::xy().rect(16.0, 10.0);
+    base.fillet(1.0);
+    let shape = base.to_face().extrude(dvec3(0.0, 0.0, 3.0));
+    let mut shape = shape.to_shape();
+
+    let top_edges: Vec<_> =
+        shape.faces().farthest(Direction::PosZ).expect("Should have a top face").edges().collect();
+
+    shape.chamfer_edges(0.7, &top_edges);
+
+    shape.write_stl("rounded_chamfer.stl").unwrap();
+}

--- a/crates/opencascade/src/primitives.rs
+++ b/crates/opencascade/src/primitives.rs
@@ -279,10 +279,10 @@ impl Wire {
     /// Chamfer the wire edges at each vertex by a given distance
     ///
     /// If distance2 is None, then the chamfer is symmetric
-    pub fn chamfer(&mut self, distance_1: f64, distance_2: Option<f64>) {
+    pub fn chamfer(&mut self, distance_1: f64) {
         // Create a face from this wire
         let mut face = Face::from_wire(self);
-        face.chamfer(distance_1, distance_2);
+        face.chamfer(distance_1);
 
         let wire = outer_wire(&face.inner);
 
@@ -443,8 +443,9 @@ impl Face {
     /// Chamfer the wire edges at each vertex by a given distance
     ///
     /// If distance2 is None, then the chamfer is symmetric
-    pub fn chamfer(&mut self, distance_1: f64, distance_2: Option<f64>) {
-        let distance_2 = distance_2.unwrap_or(distance_1);
+    pub fn chamfer(&mut self, distance_1: f64) {
+        // TODO - Support asymmetric chamfers.
+        let distance_2 = distance_1;
 
         // add all vertices from the face
         let face_shape = cast_face_to_shape(&self.inner);

--- a/crates/opencascade/src/primitives.rs
+++ b/crates/opencascade/src/primitives.rs
@@ -508,12 +508,12 @@ impl Face {
         // chamfer at vertex of all edges
         for i in 1..=vertex_map.Extent() {
             let edges = shape_list_to_vector(data_map.FindFromIndex(i));
-            let edge1 = edges.get(0).expect("Vertex has no edges");
-            let edge2 = edges.get(1).expect("Vertex has only one edge");
+            let edge_1 = edges.get(0).expect("Vertex has no edges");
+            let edge_2 = edges.get(1).expect("Vertex has only one edge");
             BRepFilletAPI_MakeFillet2d_add_chamfer(
                 make_fillet.pin_mut(),
-                TopoDS_cast_to_edge(edge1),
-                TopoDS_cast_to_edge(edge2),
+                TopoDS_cast_to_edge(edge_1),
+                TopoDS_cast_to_edge(edge_2),
                 distance_1,
                 distance_2,
             );


### PR DESCRIPTION
I wanted to get up to speed with the Open CASCADE stuff so thought I'd give https://github.com/bschwind/opencascade-rs/issues/39 a go. I saw that the `chamfer_edges` is in the lib `Shape` but this adds to the primitives. It uses the `AddChamfer` function from the `MakeFillet2d`.

There are a couple of bits I'm not sure of so I'll comment at those lines. Tested by adding

```
    let mut shell_bottom = Workplane::xy().rect(bx - thickness * 2.0, by - thickness * 2.0);
    shell_bottom.chamfer_angle(2.0, 0.78);

    let mut shell_mid = Workplane::xy()
        .transformed(dvec3(0.0, 0.0, height / 4.0), dvec3(0.0, 0.0, 0.0))
        .rect(bx - thickness * 3.0, by - thickness * 3.0);
    shell_mid.chamfer_angle(1.0, 0.78);

    let mut shell_top = Workplane::xy()
        .transformed(dvec3(0.0, 0.0, height - height / 4.0 - 4.5), dvec3(angle, 0.0, 0.0))
        .rect(tx - thickness * 2.0 + 0.5, ty - thickness * 2.0 + 0.5);
    shell_top.chamfer_angle(1.0, 0.78);
```

to the keycap one can get a nice tapering chamfer. I think you said the keycap cross requires a chamfer too? I didn't want to change that too much whilst https://github.com/bschwind/opencascade-rs/pull/74 is open.

<img width="936" alt="Screenshot 2023-07-11 at 17 28 22" src="https://github.com/bschwind/opencascade-rs/assets/1886746/91a3e233-ed1f-4b9d-a8d8-41a39a154df1">

Resolves #39
Resolves #78