### PR TITLE
Add missing workplanes and affine transforms (plus bonus gizmo geometry)

### DIFF
--- a/crates/opencascade/src/workplane.rs
+++ b/crates/opencascade/src/workplane.rs
@@ -37,69 +37,48 @@ impl Plane {
                 dvec3(1.0, 0.0, 0.0),
                 dvec3(0.0, 0.0, 0.0),
             ),
-            Self::ZX => {
-                // TODO - fix this
-                DAffine3::from_cols(
-                    dvec3(1.0, 0.0, 0.0),
-                    dvec3(0.0, 1.0, 0.0),
-                    dvec3(0.0, 0.0, 1.0),
-                    dvec3(0.0, 0.0, 0.0),
-                )
-            },
-            Self::XZ => {
-                // TODO - fix this
-                DAffine3::from_cols(
-                    dvec3(1.0, 0.0, 0.0),
-                    dvec3(0.0, 1.0, 0.0),
-                    dvec3(0.0, 0.0, 1.0),
-                    dvec3(0.0, 0.0, 0.0),
-                )
-            },
-            Self::YX => {
-                // TODO - fix this
-                DAffine3::from_cols(
-                    dvec3(1.0, 0.0, 0.0),
-                    dvec3(0.0, 1.0, 0.0),
-                    dvec3(0.0, 0.0, 1.0),
-                    dvec3(0.0, 0.0, 0.0),
-                )
-            },
-            Self::ZY => {
-                // TODO - fix this
-                DAffine3::from_cols(
-                    dvec3(1.0, 0.0, 0.0),
-                    dvec3(0.0, 1.0, 0.0),
-                    dvec3(0.0, 0.0, 1.0),
-                    dvec3(0.0, 0.0, 0.0),
-                )
-            },
-            Self::Front => {
-                // TODO - fix this
-                DAffine3::from_cols(
-                    dvec3(1.0, 0.0, 0.0),
-                    dvec3(0.0, 1.0, 0.0),
-                    dvec3(0.0, 0.0, 1.0),
-                    dvec3(0.0, 0.0, 0.0),
-                )
-            },
-            Self::Back => {
-                // TODO - fix this
-                DAffine3::from_cols(
-                    dvec3(1.0, 0.0, 0.0),
-                    dvec3(0.0, 1.0, 0.0),
-                    dvec3(0.0, 0.0, 1.0),
-                    dvec3(0.0, 0.0, 0.0),
-                )
-            },
-            Self::Left => {
-                // TODO - fix this
-                DAffine3::from_cols(
-                    dvec3(1.0, 0.0, 0.0),
-                    dvec3(0.0, 1.0, 0.0),
-                    dvec3(0.0, 0.0, 1.0),
-                    dvec3(0.0, 0.0, 0.0),
-                )
-            },
+            Self::ZX => DAffine3::from_cols(
+                dvec3(0.0, 0.0, 1.0),
+                dvec3(1.0, 0.0, 0.0),
+                dvec3(0.0, 1.0, 0.0),
+                dvec3(0.0, 0.0, 0.0),
+            ),
+            Self::XZ => DAffine3::from_cols(
+                dvec3(1.0, 0.0, 0.0),
+                dvec3(0.0, 0.0, 1.0),
+                dvec3(0.0, -1.0, 0.0),
+                dvec3(0.0, 0.0, 0.0),
+            ),
+            Self::YX => DAffine3::from_cols(
+                dvec3(0.0, 1.0, 0.0),
+                dvec3(1.0, 0.0, 0.0),
+                dvec3(0.0, 0.0, -1.0),
+                dvec3(0.0, 0.0, 0.0),
+            ),
+            Self::ZY => DAffine3::from_cols(
+                dvec3(0.0, 0.0, 1.0),
+                dvec3(0.0, 1.0, 0.0),
+                dvec3(-1.0, 0.0, 0.0),
+                dvec3(0.0, 0.0, 0.0),
+            ),
+            Self::Front => DAffine3::from_cols(
+                dvec3(1.0, 0.0, 0.0),
+                dvec3(0.0, 1.0, 0.0),
+                dvec3(0.0, 0.0, 1.0),
+                dvec3(0.0, 0.0, 0.0),
+            ),
+            Self::Back => DAffine3::from_cols(
+                dvec3(-1.0, 0.0, 0.0),
+                dvec3(0.0, 1.0, 0.0),
+                dvec3(0.0, 0.0, -1.0),
+                dvec3(0.0, 0.0, 0.0),
+            ),
+            Self::Left => DAffine3::from_cols(
+                dvec3(0.0, 0.0, 1.0),
+                dvec3(0.0, 1.0, 0.0),
+                dvec3(-1.0, 0.0, 0.0),
+                dvec3(0.0, 0.0, 0.0),
+            ),
             Self::Right => DAffine3::from_cols(
                 dvec3(0.0, 0.0, -1.0),
                 dvec3(0.0, 1.0, 0.0),
@@ -112,15 +91,12 @@ impl Plane {
                 dvec3(0.0, 1.0, 0.0),
                 dvec3(0.0, 0.0, 0.0),
             ),
-            Self::Bottom => {
-                // TODO - fix this
-                DAffine3::from_cols(
-                    dvec3(1.0, 0.0, 0.0),
-                    dvec3(0.0, 1.0, 0.0),
-                    dvec3(0.0, 0.0, 1.0),
-                    dvec3(0.0, 0.0, 0.0),
-                )
-            },
+            Self::Bottom => DAffine3::from_cols(
+                dvec3(1.0, 0.0, 0.0),
+                dvec3(0.0, 0.0, 1.0),
+                dvec3(0.0, -1.0, 0.0),
+                dvec3(0.0, 0.0, 0.0),
+            ),
             Self::Custom { x_dir, normal_dir } => {
                 let x_axis = dvec3(x_dir.0, x_dir.1, x_dir.2);
                 let z_axis = dvec3(normal_dir.0, normal_dir.1, normal_dir.2);
@@ -154,6 +130,22 @@ impl Workplane {
 
     pub fn yz() -> Self {
         Self { transform: Plane::YZ.transform() }
+    }
+
+    pub fn zx() -> Self {
+        Self { transform: Plane::ZX.transform() }
+    }
+
+    pub fn xz() -> Self {
+        Self { transform: Plane::XZ.transform() }
+    }
+
+    pub fn zy() -> Self {
+        Self { transform: Plane::ZY.transform() }
+    }
+
+    pub fn yx() -> Self {
+        Self { transform: Plane::YX.transform() }
     }
 
     pub fn origin(&self) -> DVec3 {

--- a/crates/opencascade/src/workplane.rs
+++ b/crates/opencascade/src/workplane.rs
@@ -25,82 +25,22 @@ impl Plane {
 
     pub fn transform(&self) -> DAffine3 {
         match self {
-            Self::XY => DAffine3::from_cols(
-                dvec3(1.0, 0.0, 0.0),
-                dvec3(0.0, 1.0, 0.0),
-                dvec3(0.0, 0.0, 1.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::YZ => DAffine3::from_cols(
-                dvec3(0.0, 1.0, 0.0),
-                dvec3(0.0, 0.0, 1.0),
-                dvec3(1.0, 0.0, 0.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::ZX => DAffine3::from_cols(
-                dvec3(0.0, 0.0, 1.0),
-                dvec3(1.0, 0.0, 0.0),
-                dvec3(0.0, 1.0, 0.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::XZ => DAffine3::from_cols(
-                dvec3(1.0, 0.0, 0.0),
-                dvec3(0.0, 0.0, 1.0),
-                dvec3(0.0, -1.0, 0.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::YX => DAffine3::from_cols(
-                dvec3(0.0, 1.0, 0.0),
-                dvec3(1.0, 0.0, 0.0),
-                dvec3(0.0, 0.0, -1.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::ZY => DAffine3::from_cols(
-                dvec3(0.0, 0.0, 1.0),
-                dvec3(0.0, 1.0, 0.0),
-                dvec3(-1.0, 0.0, 0.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::Front => DAffine3::from_cols(
-                dvec3(1.0, 0.0, 0.0),
-                dvec3(0.0, 1.0, 0.0),
-                dvec3(0.0, 0.0, 1.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::Back => DAffine3::from_cols(
-                dvec3(-1.0, 0.0, 0.0),
-                dvec3(0.0, 1.0, 0.0),
-                dvec3(0.0, 0.0, -1.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::Left => DAffine3::from_cols(
-                dvec3(0.0, 0.0, 1.0),
-                dvec3(0.0, 1.0, 0.0),
-                dvec3(-1.0, 0.0, 0.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::Right => DAffine3::from_cols(
-                dvec3(0.0, 0.0, -1.0),
-                dvec3(0.0, 1.0, 0.0),
-                dvec3(1.0, 0.0, 0.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::Top => DAffine3::from_cols(
-                dvec3(1.0, 0.0, 0.0),
-                dvec3(0.0, 0.0, -1.0),
-                dvec3(0.0, 1.0, 0.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
-            Self::Bottom => DAffine3::from_cols(
-                dvec3(1.0, 0.0, 0.0),
-                dvec3(0.0, 0.0, 1.0),
-                dvec3(0.0, -1.0, 0.0),
-                dvec3(0.0, 0.0, 0.0),
-            ),
+            Self::XY => DAffine3::from_cols(DVec3::X, DVec3::Y, DVec3::Z, DVec3::ZERO),
+            Self::YZ => DAffine3::from_cols(DVec3::Y, DVec3::Z, DVec3::X, DVec3::ZERO),
+            Self::ZX => DAffine3::from_cols(DVec3::Z, DVec3::X, DVec3::Y, DVec3::ZERO),
+            Self::XZ => DAffine3::from_cols(DVec3::X, DVec3::Z, DVec3::NEG_Y, DVec3::ZERO),
+            Self::YX => DAffine3::from_cols(DVec3::Y, DVec3::X, DVec3::NEG_Z, DVec3::ZERO),
+            Self::ZY => DAffine3::from_cols(DVec3::Z, DVec3::Y, DVec3::NEG_X, DVec3::ZERO),
+            Self::Front => DAffine3::from_cols(DVec3::X, DVec3::Y, DVec3::Z, DVec3::ZERO),
+            Self::Back => DAffine3::from_cols(DVec3::NEG_X, DVec3::Y, DVec3::NEG_Z, DVec3::ZERO),
+            Self::Left => DAffine3::from_cols(DVec3::Z, DVec3::Y, DVec3::NEG_X, DVec3::ZERO),
+            Self::Right => DAffine3::from_cols(DVec3::NEG_Z, DVec3::Y, DVec3::X, DVec3::ZERO),
+            Self::Top => DAffine3::from_cols(DVec3::X, DVec3::NEG_Z, DVec3::Y, DVec3::ZERO),
+            Self::Bottom => DAffine3::from_cols(DVec3::X, DVec3::Z, DVec3::NEG_Y, DVec3::ZERO),
             Self::Custom { x_dir, normal_dir } => {
-                let x_axis = dvec3(x_dir.0, x_dir.1, x_dir.2);
-                let z_axis = dvec3(normal_dir.0, normal_dir.1, normal_dir.2);
-                let y_axis = z_axis.cross(x_axis);
+                let x_axis = dvec3(x_dir.0, x_dir.1, x_dir.2).normalize();
+                let z_axis = dvec3(normal_dir.0, normal_dir.1, normal_dir.2).normalize();
+                let y_axis = z_axis.cross(x_axis).normalize();
 
                 DAffine3::from_cols(x_axis, y_axis, z_axis, DVec3::ZERO)
             },
@@ -165,8 +105,8 @@ impl Workplane {
 
         let translation = self.transform.translation;
 
-        let x_dir = dvec3(1.0, 0.0, 0.0);
-        let normal_dir = dvec3(0.0, 0.0, 1.0);
+        let x_dir = DVec3::X;
+        let normal_dir = DVec3::Z;
 
         self.transform = Plane::Custom {
             x_dir: rotation_matrix.mul_vec3(x_dir).into(),
@@ -185,8 +125,8 @@ impl Workplane {
 
         let translation = self.transform.translation;
 
-        let x_dir = rotation_matrix.mul_vec3(dvec3(1.0, 0.0, 0.0));
-        let normal_dir = rotation_matrix.mul_vec3(dvec3(0.0, 0.0, 1.0));
+        let x_dir = rotation_matrix.mul_vec3(DVec3::X);
+        let normal_dir = rotation_matrix.mul_vec3(DVec3::Z);
 
         self.transform = Plane::Custom {
             x_dir: self.transform.transform_vector3(x_dir).into(),

--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -46,16 +46,17 @@ impl GameApp for ViewerApp {
     fn init(graphics_device: &mut GraphicsDevice) -> Self {
         // Model sourced from:
         // https://nist.gov/ctl/smart-connected-systems-division/smart-connected-manufacturing-systems-group/mbe-pmi-0
-        let keycap = Shape::read_step("crates/viewer/models/nist_ftc_06.step");
+        // let arrow = Shape::read_step("crates/viewer/models/nist_ftc_06.step");
+        let arrow = gizmo();
 
-        let mesh = keycap.mesh();
+        let mesh = arrow.mesh();
         let cad_mesh = CadMesh::from_mesh(&mesh, graphics_device.device());
 
         // Pre-render the model edges.
         let line_thickness = 3.0;
         let mut line_builder = LineBuilder::new();
 
-        for edge in keycap.edges() {
+        for edge in arrow.edges() {
             let mut segments = vec![];
 
             let mut last_point: Option<DVec3> = None;
@@ -337,6 +338,22 @@ fn keycap() -> Shape {
     let (keycap, _edges) = keycap.subtract(&shell);
 
     keycap
+}
+
+#[allow(unused)]
+fn gizmo() -> Shape {
+    let arrow_length = 10.0;
+    let cone_height = 2.0;
+
+    let mut cylinder =
+        Workplane::xy().circle(0.0, 0.0, 0.1).to_face().extrude(DVec3::new(0.0, 0.0, arrow_length));
+    let cone_base = Workplane::xy()
+        .translated(DVec3::new(0.0, 0.0, arrow_length - cone_height))
+        .circle(0.0, 0.0, 1.0);
+    let cone_top =
+        Workplane::xy().translated(DVec3::new(0.0, 0.0, arrow_length)).circle(0.0, 0.0, 0.05);
+    let cone = Solid::loft([&cone_base, &cone_top].into_iter());
+    cylinder.union(&cone)
 }
 
 fn main() {


### PR DESCRIPTION
The point of this PR is just to get the missing affine transforms in the main branch quickly, but since the `viewer` main does have a bit of a soup of geometries already, I figured I'd also throw in the gizmo in progress (will use that shape as a basis for the actual gizmo behaviour).