### PR TITLE
Refer to FFI items as `ffi::foo...` instead of importing each of them

### DIFF
--- a/crates/opencascade/src/adhoc.rs
+++ b/crates/opencascade/src/adhoc.rs
@@ -1,16 +1,7 @@
 use crate::primitives::Shape;
 use cxx::UniquePtr;
 use glam::DVec3;
-use opencascade_sys::ffi::{
-    gp_Ax1_ctor, gp_Ax2_ctor, gp_DZ, gp_Dir_ctor, new_HandleGeomCurve_from_HandleGeom_TrimmedCurve,
-    new_point, new_vec, write_stl, BRepAlgoAPI_Common_ctor, BRepAlgoAPI_Cut_ctor,
-    BRepAlgoAPI_Fuse_ctor, BRepBuilderAPI_MakeEdge_HandleGeomCurve, BRepBuilderAPI_MakeFace_wire,
-    BRepBuilderAPI_MakeWire, BRepBuilderAPI_MakeWire_ctor, BRepFeat_MakeCylindricalHole_ctor,
-    BRepFilletAPI_MakeChamfer_ctor, BRepFilletAPI_MakeFillet_ctor, BRepMesh_IncrementalMesh_ctor,
-    BRepPrimAPI_MakeBox_ctor, BRepPrimAPI_MakeCylinder_ctor, BRepPrimAPI_MakePrism_ctor,
-    GC_MakeSegment_Value, GC_MakeSegment_point_point, StlAPI_Writer_ctor, TopAbs_ShapeEnum,
-    TopExp_Explorer_ctor, TopoDS_Shape, TopoDS_Shape_to_owned, TopoDS_cast_to_edge,
-};
+use opencascade_sys::ffi;
 use std::{
     ops::{Deref, DerefMut},
     path::Path,
@@ -36,15 +27,15 @@ impl DerefMut for AdHocShape {
 
 impl AdHocShape {
     /// Internal helper to create [Self] from the FFI inner type.
-    fn from_inner(inner: UniquePtr<TopoDS_Shape>) -> Self {
+    fn from_inner(inner: UniquePtr<ffi::TopoDS_Shape>) -> Self {
         Self(Shape { inner })
     }
 
     /// Make a box with a corner at (0,0,0) and with size (x,y,z)
     pub fn make_box(x: f64, y: f64, z: f64) -> Self {
-        let point = new_point(0.0, 0.0, 0.0);
-        let mut my_box = BRepPrimAPI_MakeBox_ctor(&point, x, y, z);
-        let inner = TopoDS_Shape_to_owned(my_box.pin_mut().Shape());
+        let point = ffi::new_point(0.0, 0.0, 0.0);
+        let mut my_box = ffi::BRepPrimAPI_MakeBox_ctor(&point, x, y, z);
+        let inner = ffi::TopoDS_Shape_to_owned(my_box.pin_mut().Shape());
 
         Self::from_inner(inner)
     }
@@ -55,22 +46,22 @@ impl AdHocShape {
         let min_corner = p1.min(p2);
         let max_corner = p1.max(p2);
 
-        let point = new_point(min_corner.x, min_corner.y, min_corner.z);
+        let point = ffi::new_point(min_corner.x, min_corner.y, min_corner.z);
         let diff = max_corner - min_corner;
-        let mut my_box = BRepPrimAPI_MakeBox_ctor(&point, diff.x, diff.y, diff.z);
-        let inner = TopoDS_Shape_to_owned(my_box.pin_mut().Shape());
+        let mut my_box = ffi::BRepPrimAPI_MakeBox_ctor(&point, diff.x, diff.y, diff.z);
+        let inner = ffi::TopoDS_Shape_to_owned(my_box.pin_mut().Shape());
 
         Self::from_inner(inner)
     }
 
     /// Make a cylinder with its bottom at point p, with radius r and height h.
     pub fn make_cylinder(p: DVec3, r: f64, h: f64) -> Self {
-        let point = new_point(p.x, p.y, p.z);
-        let cylinder_axis = gp_DZ();
-        let cylinder_coord_system = gp_Ax2_ctor(&point, cylinder_axis);
+        let point = ffi::new_point(p.x, p.y, p.z);
+        let cylinder_axis = ffi::gp_DZ();
+        let cylinder_coord_system = ffi::gp_Ax2_ctor(&point, cylinder_axis);
 
-        let mut cylinder = BRepPrimAPI_MakeCylinder_ctor(&cylinder_coord_system, r, h);
-        let inner = TopoDS_Shape_to_owned(cylinder.pin_mut().Shape());
+        let mut cylinder = ffi::BRepPrimAPI_MakeCylinder_ctor(&cylinder_coord_system, r, h);
+        let inner = ffi::TopoDS_Shape_to_owned(cylinder.pin_mut().Shape());
 
         Self::from_inner(inner)
     }
@@ -81,18 +72,18 @@ impl AdHocShape {
     pub fn extrude_polygon(points: &[DVec3], h: f64) -> Self {
         assert!(points.len() >= 3);
 
-        let mut make_wire = BRepBuilderAPI_MakeWire_ctor();
+        let mut make_wire = ffi::BRepBuilderAPI_MakeWire_ctor();
 
         let add_segment =
-            |p1: DVec3, p2: DVec3, make_wire: &mut UniquePtr<BRepBuilderAPI_MakeWire>| {
-                let p1 = new_point(p1.x, p1.y, p1.z);
-                let p2 = new_point(p2.x, p2.y, p2.z);
+            |p1: DVec3, p2: DVec3, make_wire: &mut UniquePtr<ffi::BRepBuilderAPI_MakeWire>| {
+                let p1 = ffi::new_point(p1.x, p1.y, p1.z);
+                let p2 = ffi::new_point(p2.x, p2.y, p2.z);
 
-                let segment = GC_MakeSegment_point_point(&p1, &p2);
-                let mut edge = BRepBuilderAPI_MakeEdge_HandleGeomCurve(
-                    &new_HandleGeomCurve_from_HandleGeom_TrimmedCurve(&GC_MakeSegment_Value(
-                        &segment,
-                    )),
+                let segment = ffi::GC_MakeSegment_point_point(&p1, &p2);
+                let mut edge = ffi::BRepBuilderAPI_MakeEdge_HandleGeomCurve(
+                    &ffi::new_HandleGeomCurve_from_HandleGeom_TrimmedCurve(
+                        &ffi::GC_MakeSegment_Value(&segment),
+                    ),
                 );
 
                 make_wire.pin_mut().add_edge(edge.pin_mut().Edge());
@@ -105,12 +96,16 @@ impl AdHocShape {
         add_segment(*points.last().unwrap(), points[0], &mut make_wire);
 
         let wire_profile = make_wire.pin_mut().Wire();
-        let mut face_profile = BRepBuilderAPI_MakeFace_wire(wire_profile, false);
-        let prism_vec = new_vec(0.0, 0.0, h);
-        let mut extrusion =
-            BRepPrimAPI_MakePrism_ctor(face_profile.pin_mut().Shape(), &prism_vec, false, true);
+        let mut face_profile = ffi::BRepBuilderAPI_MakeFace_wire(wire_profile, false);
+        let prism_vec = ffi::new_vec(0.0, 0.0, h);
+        let mut extrusion = ffi::BRepPrimAPI_MakePrism_ctor(
+            face_profile.pin_mut().Shape(),
+            &prism_vec,
+            false,
+            true,
+        );
 
-        let inner = TopoDS_Shape_to_owned(extrusion.pin_mut().Shape());
+        let inner = ffi::TopoDS_Shape_to_owned(extrusion.pin_mut().Shape());
 
         Self::from_inner(inner)
     }
@@ -118,32 +113,32 @@ impl AdHocShape {
     /// Drills a cylindrical hole starting at point p, pointing down the Z axis
     /// (this will later change to be an arbitrary axis).
     pub fn drill_hole(&mut self, p: DVec3, dir: DVec3, radius: f64) {
-        let point = new_point(p.x, p.y, p.z);
-        let dir = gp_Dir_ctor(dir.x, dir.y, dir.z);
+        let point = ffi::new_point(p.x, p.y, p.z);
+        let dir = ffi::gp_Dir_ctor(dir.x, dir.y, dir.z);
 
-        let hole_axis = gp_Ax1_ctor(&point, &dir);
+        let hole_axis = ffi::gp_Ax1_ctor(&point, &dir);
 
-        // let cylinder_axis = gp_DZ();
-        // let cylinder_coord_system = gp_Ax2_ctor(&point, cylinder_axis);
+        // let cylinder_axis = ffi::gp_DZ();
+        // let cylinder_coord_system = ffi::gp_Ax2_ctor(&point, cylinder_axis);
 
-        let mut make_hole = BRepFeat_MakeCylindricalHole_ctor();
+        let mut make_hole = ffi::BRepFeat_MakeCylindricalHole_ctor();
         make_hole.pin_mut().Init(&self.inner, &hole_axis);
 
         make_hole.pin_mut().Perform(radius);
         make_hole.pin_mut().Build();
 
-        // let mut cylinder = BRepPrimAPI_MakeCylinder_ctor(&cylinder_coord_system, r, h);
-        // let shape = TopoDS_Shape_to_owned(cylinder.pin_mut().Shape());
+        // let mut cylinder = ffi::BRepPrimAPI_MakeCylinder_ctor(&cylinder_coord_system, r, h);
+        // let shape = ffi::TopoDS_Shape_to_owned(cylinder.pin_mut().Shape());
 
         // Self { shape }
 
-        self.inner = TopoDS_Shape_to_owned(make_hole.pin_mut().Shape());
+        self.inner = ffi::TopoDS_Shape_to_owned(make_hole.pin_mut().Shape());
     }
 
     pub fn write_stl<P: AsRef<Path>>(&self, path: P) {
-        let mut stl_writer = StlAPI_Writer_ctor();
-        let triangulation = BRepMesh_IncrementalMesh_ctor(&self.inner, 0.001);
-        let success = write_stl(
+        let mut stl_writer = ffi::StlAPI_Writer_ctor();
+        let triangulation = ffi::BRepMesh_IncrementalMesh_ctor(&self.inner, 0.001);
+        let success = ffi::write_stl(
             stl_writer.pin_mut(),
             triangulation.Shape(),
             path.as_ref().to_string_lossy().to_string(),
@@ -153,53 +148,55 @@ impl AdHocShape {
     }
 
     pub fn fillet_edges(&mut self, radius: f64) {
-        let mut make_fillet = BRepFilletAPI_MakeFillet_ctor(&self.inner);
-        let mut edge_explorer = TopExp_Explorer_ctor(&self.inner, TopAbs_ShapeEnum::TopAbs_EDGE);
+        let mut make_fillet = ffi::BRepFilletAPI_MakeFillet_ctor(&self.inner);
+        let mut edge_explorer =
+            ffi::TopExp_Explorer_ctor(&self.inner, ffi::TopAbs_ShapeEnum::TopAbs_EDGE);
 
         while edge_explorer.More() {
-            let edge = TopoDS_cast_to_edge(edge_explorer.Current());
+            let edge = ffi::TopoDS_cast_to_edge(edge_explorer.Current());
             make_fillet.pin_mut().add_edge(radius, edge);
             edge_explorer.pin_mut().Next();
         }
 
         let filleted_shape = make_fillet.pin_mut().Shape();
 
-        self.inner = TopoDS_Shape_to_owned(filleted_shape);
+        self.inner = ffi::TopoDS_Shape_to_owned(filleted_shape);
     }
 
     pub fn chamfer_edges(&mut self, distance: f64) {
-        let mut make_chamfer = BRepFilletAPI_MakeChamfer_ctor(&self.inner);
-        let mut edge_explorer = TopExp_Explorer_ctor(&self.inner, TopAbs_ShapeEnum::TopAbs_EDGE);
+        let mut make_chamfer = ffi::BRepFilletAPI_MakeChamfer_ctor(&self.inner);
+        let mut edge_explorer =
+            ffi::TopExp_Explorer_ctor(&self.inner, ffi::TopAbs_ShapeEnum::TopAbs_EDGE);
 
         while edge_explorer.More() {
-            let edge = TopoDS_cast_to_edge(edge_explorer.Current());
+            let edge = ffi::TopoDS_cast_to_edge(edge_explorer.Current());
             make_chamfer.pin_mut().add_edge(distance, edge);
             edge_explorer.pin_mut().Next();
         }
 
         let filleted_shape = make_chamfer.pin_mut().Shape();
 
-        self.inner = TopoDS_Shape_to_owned(filleted_shape);
+        self.inner = ffi::TopoDS_Shape_to_owned(filleted_shape);
     }
 
     pub fn subtract(&mut self, other: &Shape) {
-        let mut cut_operation = BRepAlgoAPI_Cut_ctor(&self.inner, &other.inner);
+        let mut cut_operation = ffi::BRepAlgoAPI_Cut_ctor(&self.inner, &other.inner);
 
         let cut_shape = cut_operation.pin_mut().Shape();
-        self.inner = TopoDS_Shape_to_owned(cut_shape);
+        self.inner = ffi::TopoDS_Shape_to_owned(cut_shape);
     }
 
     pub fn union(&mut self, other: &Shape) {
-        let mut fuse_operation = BRepAlgoAPI_Fuse_ctor(&self.inner, &other.inner);
+        let mut fuse_operation = ffi::BRepAlgoAPI_Fuse_ctor(&self.inner, &other.inner);
 
         let cut_shape = fuse_operation.pin_mut().Shape();
-        self.inner = TopoDS_Shape_to_owned(cut_shape);
+        self.inner = ffi::TopoDS_Shape_to_owned(cut_shape);
     }
 
     pub fn intersect(&mut self, other: &Shape) {
-        let mut common_operation = BRepAlgoAPI_Common_ctor(&self.inner, &other.inner);
+        let mut common_operation = ffi::BRepAlgoAPI_Common_ctor(&self.inner, &other.inner);
 
         let cut_shape = common_operation.pin_mut().Shape();
-        self.inner = TopoDS_Shape_to_owned(cut_shape);
+        self.inner = ffi::TopoDS_Shape_to_owned(cut_shape);
     }
 }

--- a/crates/opencascade/src/primitives.rs
+++ b/crates/opencascade/src/primitives.rs
@@ -1015,7 +1015,8 @@ impl Mesher {
             let triangulation_handle =
                 ffi::BRep_Tool_Triangulation(&face.inner, location.pin_mut());
 
-            let Ok(triangulation) = ffi::Handle_Poly_Triangulation_Get(&triangulation_handle) else {
+            let Ok(triangulation) = ffi::Handle_Poly_Triangulation_Get(&triangulation_handle)
+            else {
                 // TODO(bschwind) - Do better error handling, use Results.
                 println!("Encountered a face with no triangulation");
                 continue;

--- a/crates/opencascade/src/primitives.rs
+++ b/crates/opencascade/src/primitives.rs
@@ -1,37 +1,7 @@
 use crate::{workplane::Workplane, Error};
 use cxx::UniquePtr;
 use glam::{dvec2, dvec3, DVec2, DVec3};
-use opencascade_sys::ffi::{
-    cast_compound_to_shape, cast_face_to_shape, cast_solid_to_shape, cast_wire_to_shape,
-    gp_Ax1_ctor, gp_Ax2, gp_Ax2_ctor, gp_Circ_ctor, gp_Dir, gp_Dir_ctor, gp_Lin_ctor, gp_Pnt,
-    gp_Vec, map_shapes, map_shapes_and_ancestors, new_HandleGeomCurve_from_HandleGeom_TrimmedCurve,
-    new_indexed_data_map_of_shape_list_of_shape, new_indexed_map_of_shape, new_point,
-    new_transform, new_vec, one_shape, outer_wire, read_step, shape_list_to_vector,
-    triangulated_shape_normal, write_stl, BRepAdaptor_Curve_ctor, BRepAdaptor_Curve_value,
-    BRepAlgoAPI_Cut_ctor, BRepAlgoAPI_Fuse_ctor, BRepBuilderAPI_MakeEdge_HandleGeomCurve,
-    BRepBuilderAPI_MakeEdge_circle, BRepBuilderAPI_MakeEdge_gp_Pnt_gp_Pnt,
-    BRepBuilderAPI_MakeFace_wire, BRepBuilderAPI_MakeVertex_gp_Pnt, BRepBuilderAPI_MakeWire_ctor,
-    BRepBuilderAPI_Transform_ctor, BRepFeat_MakeDPrism_ctor, BRepFilletAPI_MakeChamfer_ctor,
-    BRepFilletAPI_MakeFillet2d_add_chamfer, BRepFilletAPI_MakeFillet2d_add_fillet,
-    BRepFilletAPI_MakeFillet2d_ctor, BRepFilletAPI_MakeFillet_ctor, BRepGProp_Face_ctor,
-    BRepGProp_SurfaceProperties, BRepIntCurveSurface_Inter_ctor, BRepIntCurveSurface_Inter_face,
-    BRepIntCurveSurface_Inter_point, BRepMesh_IncrementalMesh, BRepMesh_IncrementalMesh_ctor,
-    BRepOffsetAPI_ThruSections_ctor, BRepPrimAPI_MakePrism_ctor, BRep_Tool_Surface,
-    BRep_Tool_Triangulation, GCPnts_TangentialDeflection, GCPnts_TangentialDeflection_Value,
-    GCPnts_TangentialDeflection_ctor, GC_MakeArcOfCircle_Value,
-    GC_MakeArcOfCircle_point_point_point, GProp_GProps_CentreOfMass, GProp_GProps_ctor,
-    GeomAPI_ProjectPointOnSurf_ctor, Handle_Poly_Triangulation_Get, Message_ProgressRange_ctor,
-    Poly_Connect_ctor, Poly_Triangulation_Node, Poly_Triangulation_UV, STEPControl_Reader_ctor,
-    ShapeUpgrade_UnifySameDomain_ctor, StlAPI_Writer_ctor, TColgp_Array1OfDir_Value,
-    TColgp_Array1OfDir_ctor, TopAbs_Orientation, TopAbs_ShapeEnum, TopExp_Explorer,
-    TopExp_Explorer_ctor, TopLoc_Location_Transformation, TopLoc_Location_ctor,
-    TopLoc_Location_from_transform, TopoDS_Compound, TopoDS_Compound_to_owned, TopoDS_Edge,
-    TopoDS_Edge_to_owned, TopoDS_Face, TopoDS_Face_ctor, TopoDS_Face_to_owned, TopoDS_Shape,
-    TopoDS_Shape_to_owned, TopoDS_Shell, TopoDS_Solid, TopoDS_Solid_to_owned, TopoDS_Vertex,
-    TopoDS_Vertex_to_owned, TopoDS_Wire, TopoDS_Wire_to_owned, TopoDS_cast_to_compound,
-    TopoDS_cast_to_edge, TopoDS_cast_to_face, TopoDS_cast_to_solid, TopoDS_cast_to_vertex,
-    TopoDS_cast_to_wire,
-};
+use opencascade_sys::ffi;
 use std::path::Path;
 
 #[derive(Debug, Copy, Clone)]
@@ -81,45 +51,46 @@ impl ToAngle for u64 {
     }
 }
 
-pub fn make_point(p: DVec3) -> UniquePtr<gp_Pnt> {
-    new_point(p.x, p.y, p.z)
+pub fn make_point(p: DVec3) -> UniquePtr<ffi::gp_Pnt> {
+    ffi::new_point(p.x, p.y, p.z)
 }
 
-pub fn make_dir(p: DVec3) -> UniquePtr<gp_Dir> {
-    gp_Dir_ctor(p.x, p.y, p.z)
+pub fn make_dir(p: DVec3) -> UniquePtr<ffi::gp_Dir> {
+    ffi::gp_Dir_ctor(p.x, p.y, p.z)
 }
 
-pub fn make_vec(vec: DVec3) -> UniquePtr<gp_Vec> {
-    new_vec(vec.x, vec.y, vec.z)
+pub fn make_vec(vec: DVec3) -> UniquePtr<ffi::gp_Vec> {
+    ffi::new_vec(vec.x, vec.y, vec.z)
 }
 
-pub fn make_axis_2(origin: DVec3, dir: DVec3) -> UniquePtr<gp_Ax2> {
-    gp_Ax2_ctor(&make_point(origin), &make_dir(dir))
+pub fn make_axis_2(origin: DVec3, dir: DVec3) -> UniquePtr<ffi::gp_Ax2> {
+    ffi::gp_Ax2_ctor(&make_point(origin), &make_dir(dir))
 }
 
 pub struct Vertex {
-    _inner: UniquePtr<TopoDS_Vertex>,
+    _inner: UniquePtr<ffi::TopoDS_Vertex>,
 }
 
 impl Vertex {
     pub fn new(point: DVec3) -> Self {
-        let mut make_vertex = BRepBuilderAPI_MakeVertex_gp_Pnt(&make_point(point));
+        let mut make_vertex = ffi::BRepBuilderAPI_MakeVertex_gp_Pnt(&make_point(point));
         let vertex = make_vertex.pin_mut().Vertex();
-        let inner = TopoDS_Vertex_to_owned(vertex);
+        let inner = ffi::TopoDS_Vertex_to_owned(vertex);
 
         Self { _inner: inner }
     }
 }
 
 pub struct Edge {
-    inner: UniquePtr<TopoDS_Edge>,
+    inner: UniquePtr<ffi::TopoDS_Edge>,
 }
 
 impl Edge {
     pub fn segment(p1: DVec3, p2: DVec3) -> Self {
-        let mut make_edge = BRepBuilderAPI_MakeEdge_gp_Pnt_gp_Pnt(&make_point(p1), &make_point(p2));
+        let mut make_edge =
+            ffi::BRepBuilderAPI_MakeEdge_gp_Pnt_gp_Pnt(&make_point(p1), &make_point(p2));
         let edge = make_edge.pin_mut().Edge();
-        let inner = TopoDS_Edge_to_owned(edge);
+        let inner = ffi::TopoDS_Edge_to_owned(edge);
 
         Self { inner }
     }
@@ -127,12 +98,12 @@ impl Edge {
     pub fn circle(center: DVec3, normal: DVec3, radius: f64) -> Self {
         let axis = make_axis_2(center, normal);
 
-        let make_circle = gp_Circ_ctor(&axis, radius);
+        let make_circle = ffi::gp_Circ_ctor(&axis, radius);
 
-        let mut make_edge = BRepBuilderAPI_MakeEdge_circle(&make_circle);
+        let mut make_edge = ffi::BRepBuilderAPI_MakeEdge_circle(&make_circle);
 
         let edge = make_edge.pin_mut().Edge();
-        let inner = TopoDS_Edge_to_owned(edge);
+        let inner = ffi::TopoDS_Edge_to_owned(edge);
 
         Self { inner }
     }
@@ -142,38 +113,43 @@ impl Edge {
     pub fn spline() {}
 
     pub fn arc(p1: DVec3, p2: DVec3, p3: DVec3) -> Self {
-        let make_arc =
-            GC_MakeArcOfCircle_point_point_point(&make_point(p1), &make_point(p2), &make_point(p3));
+        let make_arc = ffi::GC_MakeArcOfCircle_point_point_point(
+            &make_point(p1),
+            &make_point(p2),
+            &make_point(p3),
+        );
 
-        let mut make_edge = BRepBuilderAPI_MakeEdge_HandleGeomCurve(
-            &new_HandleGeomCurve_from_HandleGeom_TrimmedCurve(&GC_MakeArcOfCircle_Value(&make_arc)),
+        let mut make_edge = ffi::BRepBuilderAPI_MakeEdge_HandleGeomCurve(
+            &ffi::new_HandleGeomCurve_from_HandleGeom_TrimmedCurve(&ffi::GC_MakeArcOfCircle_Value(
+                &make_arc,
+            )),
         );
 
         let edge = make_edge.pin_mut().Edge();
-        let inner = TopoDS_Edge_to_owned(edge);
+        let inner = ffi::TopoDS_Edge_to_owned(edge);
 
         Self { inner }
     }
 
     pub fn start_point(&self) -> DVec3 {
-        let curve = BRepAdaptor_Curve_ctor(&self.inner);
+        let curve = ffi::BRepAdaptor_Curve_ctor(&self.inner);
         let start_param = curve.FirstParameter();
-        let point = BRepAdaptor_Curve_value(&curve, start_param);
+        let point = ffi::BRepAdaptor_Curve_value(&curve, start_param);
 
         dvec3(point.X(), point.Y(), point.Z())
     }
 
     pub fn end_point(&self) -> DVec3 {
-        let curve = BRepAdaptor_Curve_ctor(&self.inner);
+        let curve = ffi::BRepAdaptor_Curve_ctor(&self.inner);
         let last_param = curve.LastParameter();
-        let point = BRepAdaptor_Curve_value(&curve, last_param);
+        let point = ffi::BRepAdaptor_Curve_value(&curve, last_param);
 
         dvec3(point.X(), point.Y(), point.Z())
     }
 
     pub fn approximation_segments(&self) -> ApproximationSegmentIterator {
-        let adaptor_curve = BRepAdaptor_Curve_ctor(&self.inner);
-        let approximator = GCPnts_TangentialDeflection_ctor(&adaptor_curve, 0.1, 0.1);
+        let adaptor_curve = ffi::BRepAdaptor_Curve_ctor(&self.inner);
+        let approximator = ffi::GCPnts_TangentialDeflection_ctor(&adaptor_curve, 0.1, 0.1);
 
         ApproximationSegmentIterator { count: 1, approximator }
     }
@@ -183,7 +159,7 @@ impl Edge {
 
 pub struct ApproximationSegmentIterator {
     count: usize,
-    approximator: UniquePtr<GCPnts_TangentialDeflection>,
+    approximator: UniquePtr<ffi::GCPnts_TangentialDeflection>,
 }
 
 impl Iterator for ApproximationSegmentIterator {
@@ -191,7 +167,8 @@ impl Iterator for ApproximationSegmentIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.count <= self.approximator.NbPoints() as usize {
-            let point = GCPnts_TangentialDeflection_Value(&self.approximator, self.count as i32);
+            let point =
+                ffi::GCPnts_TangentialDeflection_Value(&self.approximator, self.count as i32);
 
             self.count += 1;
             Some(dvec3(point.X(), point.Y(), point.Z()))
@@ -202,51 +179,51 @@ impl Iterator for ApproximationSegmentIterator {
 }
 
 pub struct Wire {
-    inner: UniquePtr<TopoDS_Wire>,
+    inner: UniquePtr<ffi::TopoDS_Wire>,
 }
 
 impl Wire {
     pub fn from_edges<'a>(edges: impl IntoIterator<Item = &'a Edge>) -> Self {
-        let mut make_wire = BRepBuilderAPI_MakeWire_ctor();
+        let mut make_wire = ffi::BRepBuilderAPI_MakeWire_ctor();
 
         for edge in edges.into_iter() {
             make_wire.pin_mut().add_edge(&edge.inner);
         }
 
         let wire = make_wire.pin_mut().Wire();
-        let inner = TopoDS_Wire_to_owned(wire);
+        let inner = ffi::TopoDS_Wire_to_owned(wire);
 
         Self { inner }
     }
 
     pub fn from_wires<'a>(wires: impl IntoIterator<Item = &'a Wire>) -> Self {
-        let mut make_wire = BRepBuilderAPI_MakeWire_ctor();
+        let mut make_wire = ffi::BRepBuilderAPI_MakeWire_ctor();
 
         for wire in wires.into_iter() {
             make_wire.pin_mut().add_wire(&wire.inner);
         }
 
         let wire = make_wire.pin_mut().Wire();
-        let inner = TopoDS_Wire_to_owned(wire);
+        let inner = ffi::TopoDS_Wire_to_owned(wire);
 
         Self { inner }
     }
 
     pub fn mirror_along_axis(&self, axis_origin: DVec3, axis_dir: DVec3) -> Self {
         let axis_dir = make_dir(axis_dir);
-        let axis = gp_Ax1_ctor(&make_point(axis_origin), &axis_dir);
+        let axis = ffi::gp_Ax1_ctor(&make_point(axis_origin), &axis_dir);
 
-        let mut transform = new_transform();
+        let mut transform = ffi::new_transform();
 
         transform.pin_mut().set_mirror_axis(&axis);
 
-        let wire_shape = cast_wire_to_shape(&self.inner);
+        let wire_shape = ffi::cast_wire_to_shape(&self.inner);
 
-        let mut brep_transform = BRepBuilderAPI_Transform_ctor(wire_shape, &transform, false);
+        let mut brep_transform = ffi::BRepBuilderAPI_Transform_ctor(wire_shape, &transform, false);
 
         let mirrored_shape = brep_transform.pin_mut().Shape();
-        let mirrored_wire = TopoDS_cast_to_wire(mirrored_shape);
-        let inner = TopoDS_Wire_to_owned(mirrored_wire);
+        let mirrored_wire = ffi::TopoDS_cast_to_wire(mirrored_shape);
+        let inner = ffi::TopoDS_Wire_to_owned(mirrored_wire);
 
         Self { inner }
     }
@@ -272,7 +249,7 @@ impl Wire {
         // Create a face from this wire
         let mut face = Face::from_wire(self);
         face.fillet(radius);
-        let wire = outer_wire(&face.inner);
+        let wire = ffi::outer_wire(&face.inner);
 
         self.inner = wire;
     }
@@ -282,7 +259,7 @@ impl Wire {
         let mut face = Face::from_wire(self);
         face.chamfer(distance_1);
 
-        let wire = outer_wire(&face.inner);
+        let wire = ffi::outer_wire(&face.inner);
 
         self.inner = wire;
     }
@@ -294,37 +271,38 @@ impl Wire {
     pub fn transform(&mut self, translation: DVec3, rotation_axis: DVec3, angle: f64) {
         let angle = angle * std::f64::consts::PI / 180.0;
 
-        let mut transform = new_transform();
-        let rotation_axis_vec = gp_Ax1_ctor(&make_point(DVec3::ZERO), &make_dir(rotation_axis));
+        let mut transform = ffi::new_transform();
+        let rotation_axis_vec =
+            ffi::gp_Ax1_ctor(&make_point(DVec3::ZERO), &make_dir(rotation_axis));
         let translation_vec = make_vec(translation);
 
         transform.pin_mut().SetRotation(&rotation_axis_vec, angle);
         transform.pin_mut().set_translation_vec(&translation_vec);
-        let location = TopLoc_Location_from_transform(&transform);
+        let location = ffi::TopLoc_Location_from_transform(&transform);
 
-        let wire_shape = cast_wire_to_shape(&self.inner);
-        let mut wire_shape = TopoDS_Shape_to_owned(wire_shape);
+        let wire_shape = ffi::cast_wire_to_shape(&self.inner);
+        let mut wire_shape = ffi::TopoDS_Shape_to_owned(wire_shape);
 
         let raise_exception = false;
         wire_shape.pin_mut().translate(&location, raise_exception);
 
-        let translated_wire = TopoDS_cast_to_wire(&wire_shape);
-        self.inner = TopoDS_Wire_to_owned(translated_wire);
+        let translated_wire = ffi::TopoDS_cast_to_wire(&wire_shape);
+        self.inner = ffi::TopoDS_Wire_to_owned(translated_wire);
     }
 
     pub fn to_face(self) -> Face {
         let only_plane = false;
-        let make_face = BRepBuilderAPI_MakeFace_wire(&self.inner, only_plane);
+        let make_face = ffi::BRepBuilderAPI_MakeFace_wire(&self.inner, only_plane);
 
         let face = make_face.Face();
-        let inner = TopoDS_Face_to_owned(face);
+        let inner = ffi::TopoDS_Face_to_owned(face);
 
         Face { inner }
     }
 
     pub fn to_shape(self) -> Shape {
-        let inner_shape = cast_wire_to_shape(&self.inner);
-        let inner = TopoDS_Shape_to_owned(inner_shape);
+        let inner_shape = ffi::cast_wire_to_shape(&self.inner);
+        let inner = ffi::TopoDS_Shape_to_owned(inner_shape);
 
         Shape { inner }
     }
@@ -334,16 +312,16 @@ impl Wire {
 }
 
 pub struct Face {
-    inner: UniquePtr<TopoDS_Face>,
+    inner: UniquePtr<ffi::TopoDS_Face>,
 }
 
 impl Face {
     pub fn from_wire(wire: &Wire) -> Self {
         let only_plane = false;
-        let make_face = BRepBuilderAPI_MakeFace_wire(&wire.inner, only_plane);
+        let make_face = ffi::BRepBuilderAPI_MakeFace_wire(&wire.inner, only_plane);
 
         let face = make_face.Face();
-        let inner = TopoDS_Face_to_owned(face);
+        let inner = ffi::TopoDS_Face_to_owned(face);
 
         Self { inner }
     }
@@ -354,23 +332,24 @@ impl Face {
         let copy = false;
         let canonize = true;
 
-        let inner_shape = cast_face_to_shape(&self.inner);
-        let mut make_solid = BRepPrimAPI_MakePrism_ctor(inner_shape, &prism_vec, copy, canonize);
+        let inner_shape = ffi::cast_face_to_shape(&self.inner);
+        let mut make_solid =
+            ffi::BRepPrimAPI_MakePrism_ctor(inner_shape, &prism_vec, copy, canonize);
         let extruded_shape = make_solid.pin_mut().Shape();
-        let solid = TopoDS_cast_to_solid(extruded_shape);
-        let inner = TopoDS_Solid_to_owned(solid);
+        let solid = ffi::TopoDS_cast_to_solid(extruded_shape);
+        let inner = ffi::TopoDS_Solid_to_owned(solid);
 
         Solid { inner }
     }
 
     pub fn extrude_to_face(&self, shape_with_face: &Shape, face: &Face) -> Shape {
         let profile_base = &self.inner;
-        let sketch_base = TopoDS_Face_ctor();
+        let sketch_base = ffi::TopoDS_Face_ctor();
         let angle = 0.0;
         let fuse = 1; // 0 = subtractive, 1 = additive
         let modify = false;
 
-        let mut make_prism = BRepFeat_MakeDPrism_ctor(
+        let mut make_prism = ffi::BRepFeat_MakeDPrism_ctor(
             &shape_with_face.inner,
             profile_base,
             &sketch_base,
@@ -379,23 +358,23 @@ impl Face {
             modify,
         );
 
-        let until_face = cast_face_to_shape(&face.inner);
+        let until_face = ffi::cast_face_to_shape(&face.inner);
         make_prism.pin_mut().perform_until_face(until_face);
 
         let extruded_shape = make_prism.pin_mut().Shape();
-        let inner = TopoDS_Shape_to_owned(extruded_shape);
+        let inner = ffi::TopoDS_Shape_to_owned(extruded_shape);
 
         Shape { inner }
     }
 
     pub fn subtractive_extrude(&self, shape_with_face: &Shape, height: f64) -> Shape {
         let profile_base = &self.inner;
-        let sketch_base = TopoDS_Face_ctor();
+        let sketch_base = ffi::TopoDS_Face_ctor();
         let angle = 0.0;
         let fuse = 1; // 0 = subtractive, 1 = additive
         let modify = false;
 
-        let mut make_prism = BRepFeat_MakeDPrism_ctor(
+        let mut make_prism = ffi::BRepFeat_MakeDPrism_ctor(
             &shape_with_face.inner,
             profile_base,
             &sketch_base,
@@ -407,32 +386,32 @@ impl Face {
         make_prism.pin_mut().perform_with_height(height);
 
         let extruded_shape = make_prism.pin_mut().Shape();
-        let inner = TopoDS_Shape_to_owned(extruded_shape);
+        let inner = ffi::TopoDS_Shape_to_owned(extruded_shape);
 
         Shape { inner }
     }
 
     /// Fillets the face edges by a given radius at each vertex
     pub fn fillet(&mut self, radius: f64) {
-        let mut make_fillet = BRepFilletAPI_MakeFillet2d_ctor(&self.inner);
+        let mut make_fillet = ffi::BRepFilletAPI_MakeFillet2d_ctor(&self.inner);
 
-        let face_shape = cast_face_to_shape(&self.inner);
+        let face_shape = ffi::cast_face_to_shape(&self.inner);
 
         // We use a shape map here to avoid duplicates.
-        let mut shape_map = new_indexed_map_of_shape();
-        map_shapes(face_shape, TopAbs_ShapeEnum::TopAbs_VERTEX, shape_map.pin_mut());
+        let mut shape_map = ffi::new_indexed_map_of_shape();
+        ffi::map_shapes(face_shape, ffi::TopAbs_ShapeEnum::TopAbs_VERTEX, shape_map.pin_mut());
 
         for i in 1..=shape_map.Extent() {
-            let vertex = TopoDS_cast_to_vertex(shape_map.FindKey(i));
-            BRepFilletAPI_MakeFillet2d_add_fillet(make_fillet.pin_mut(), vertex, radius);
+            let vertex = ffi::TopoDS_cast_to_vertex(shape_map.FindKey(i));
+            ffi::BRepFilletAPI_MakeFillet2d_add_fillet(make_fillet.pin_mut(), vertex, radius);
         }
 
-        make_fillet.pin_mut().Build(&Message_ProgressRange_ctor());
+        make_fillet.pin_mut().Build(&ffi::Message_ProgressRange_ctor());
 
         let result_shape = make_fillet.pin_mut().Shape();
-        let result_face = TopoDS_cast_to_face(result_shape);
+        let result_face = ffi::TopoDS_cast_to_face(result_shape);
 
-        self.inner = TopoDS_Face_to_owned(result_face);
+        self.inner = ffi::TopoDS_Face_to_owned(result_face);
     }
 
     /// Chamfer the wire edges at each vertex by a given distance
@@ -440,72 +419,74 @@ impl Face {
         // TODO - Support asymmetric chamfers.
         let distance_2 = distance_1;
 
-        let face_shape = cast_face_to_shape(&self.inner);
+        let face_shape = ffi::cast_face_to_shape(&self.inner);
 
-        let mut make_fillet = BRepFilletAPI_MakeFillet2d_ctor(&self.inner);
+        let mut make_fillet = ffi::BRepFilletAPI_MakeFillet2d_ctor(&self.inner);
 
-        let mut vertex_map = new_indexed_map_of_shape();
-        map_shapes(face_shape, TopAbs_ShapeEnum::TopAbs_VERTEX, vertex_map.pin_mut());
+        let mut vertex_map = ffi::new_indexed_map_of_shape();
+        ffi::map_shapes(face_shape, ffi::TopAbs_ShapeEnum::TopAbs_VERTEX, vertex_map.pin_mut());
 
         // Get map of vertices to edges so we can find the edges connected to each vertex.
-        let mut data_map = new_indexed_data_map_of_shape_list_of_shape();
-        map_shapes_and_ancestors(
+        let mut data_map = ffi::new_indexed_data_map_of_shape_list_of_shape();
+        ffi::map_shapes_and_ancestors(
             face_shape,
-            TopAbs_ShapeEnum::TopAbs_VERTEX,
-            TopAbs_ShapeEnum::TopAbs_EDGE,
+            ffi::TopAbs_ShapeEnum::TopAbs_VERTEX,
+            ffi::TopAbs_ShapeEnum::TopAbs_EDGE,
             data_map.pin_mut(),
         );
 
         // Chamfer at vertex of all edges.
         for i in 1..=vertex_map.Extent() {
-            let edges = shape_list_to_vector(data_map.FindFromIndex(i));
+            let edges = ffi::shape_list_to_vector(data_map.FindFromIndex(i));
             let edge_1 = edges.get(0).expect("Vertex has no edges");
             let edge_2 = edges.get(1).expect("Vertex has only one edge");
-            BRepFilletAPI_MakeFillet2d_add_chamfer(
+            ffi::BRepFilletAPI_MakeFillet2d_add_chamfer(
                 make_fillet.pin_mut(),
-                TopoDS_cast_to_edge(edge_1),
-                TopoDS_cast_to_edge(edge_2),
+                ffi::TopoDS_cast_to_edge(edge_1),
+                ffi::TopoDS_cast_to_edge(edge_2),
                 distance_1,
                 distance_2,
             );
         }
 
         let filleted_shape = make_fillet.pin_mut().Shape();
-        let result_face = TopoDS_cast_to_face(filleted_shape);
+        let result_face = ffi::TopoDS_cast_to_face(filleted_shape);
 
-        self.inner = TopoDS_Face_to_owned(result_face);
+        self.inner = ffi::TopoDS_Face_to_owned(result_face);
     }
 
     pub fn edges(&self) -> EdgeIterator {
-        let explorer =
-            TopExp_Explorer_ctor(cast_face_to_shape(&self.inner), TopAbs_ShapeEnum::TopAbs_EDGE);
+        let explorer = ffi::TopExp_Explorer_ctor(
+            ffi::cast_face_to_shape(&self.inner),
+            ffi::TopAbs_ShapeEnum::TopAbs_EDGE,
+        );
 
         EdgeIterator { explorer }
     }
 
     pub fn center_of_mass(&self) -> DVec3 {
-        let mut props = GProp_GProps_ctor();
+        let mut props = ffi::GProp_GProps_ctor();
 
-        let inner_shape = cast_face_to_shape(&self.inner);
-        BRepGProp_SurfaceProperties(inner_shape, props.pin_mut());
+        let inner_shape = ffi::cast_face_to_shape(&self.inner);
+        ffi::BRepGProp_SurfaceProperties(inner_shape, props.pin_mut());
 
-        let center = GProp_GProps_CentreOfMass(&props);
+        let center = ffi::GProp_GProps_CentreOfMass(&props);
 
         dvec3(center.X(), center.Y(), center.Z())
     }
 
     pub fn normal_at(&self, pos: DVec3) -> DVec3 {
-        let surface = BRep_Tool_Surface(&self.inner);
-        let projector = GeomAPI_ProjectPointOnSurf_ctor(&make_point(pos), &surface);
+        let surface = ffi::BRep_Tool_Surface(&self.inner);
+        let projector = ffi::GeomAPI_ProjectPointOnSurf_ctor(&make_point(pos), &surface);
         let mut u: f64 = 0.0;
         let mut v: f64 = 0.0;
 
         projector.LowerDistanceParameters(&mut u, &mut v);
 
-        let mut p = new_point(0.0, 0.0, 0.0);
-        let mut normal = new_vec(0.0, 1.0, 0.0);
+        let mut p = ffi::new_point(0.0, 0.0, 0.0);
+        let mut normal = ffi::new_vec(0.0, 1.0, 0.0);
 
-        let face = BRepGProp_Face_ctor(&self.inner);
+        let face = ffi::BRepGProp_Face_ctor(&self.inner);
         face.Normal(u, v, p.pin_mut(), normal.pin_mut());
 
         dvec3(normal.X(), normal.Y(), normal.Z())
@@ -535,15 +516,15 @@ impl Face {
     }
 
     pub fn union(&self, other: &Face) -> CompoundFace {
-        let inner_shape = cast_face_to_shape(&self.inner);
-        let other_inner_shape = cast_face_to_shape(&other.inner);
+        let inner_shape = ffi::cast_face_to_shape(&self.inner);
+        let other_inner_shape = ffi::cast_face_to_shape(&other.inner);
 
-        let mut fuse_operation = BRepAlgoAPI_Fuse_ctor(inner_shape, other_inner_shape);
+        let mut fuse_operation = ffi::BRepAlgoAPI_Fuse_ctor(inner_shape, other_inner_shape);
 
         let fuse_shape = fuse_operation.pin_mut().Shape();
 
-        let compound = TopoDS_cast_to_compound(fuse_shape);
-        let inner = TopoDS_Compound_to_owned(compound);
+        let compound = ffi::TopoDS_cast_to_compound(fuse_shape);
+        let inner = ffi::TopoDS_Compound_to_owned(compound);
 
         CompoundFace { inner }
     }
@@ -553,27 +534,27 @@ impl Face {
     }
 
     pub fn from_shape(shape: &Shape) -> Self {
-        let face = TopoDS_cast_to_face(&shape.inner);
-        let inner = TopoDS_Face_to_owned(face);
+        let face = ffi::TopoDS_cast_to_face(&shape.inner);
+        let inner = ffi::TopoDS_Face_to_owned(face);
 
         Self { inner }
     }
 }
 
 pub struct CompoundFace {
-    inner: UniquePtr<TopoDS_Compound>,
+    inner: UniquePtr<ffi::TopoDS_Compound>,
 }
 
 impl CompoundFace {
     pub fn clean(&mut self) -> Self {
-        let inner = cast_compound_to_shape(&self.inner);
-        let inner = TopoDS_Shape_to_owned(inner);
+        let inner = ffi::cast_compound_to_shape(&self.inner);
+        let inner = ffi::TopoDS_Shape_to_owned(inner);
         let mut shape = Shape { inner };
 
         shape.clean();
 
-        let inner = TopoDS_cast_to_compound(&shape.inner);
-        let inner = TopoDS_Compound_to_owned(inner);
+        let inner = ffi::TopoDS_cast_to_compound(&shape.inner);
+        let inner = ffi::TopoDS_Compound_to_owned(inner);
 
         Self { inner }
     }
@@ -584,24 +565,25 @@ impl CompoundFace {
         let copy = false;
         let canonize = true;
 
-        let inner_shape = cast_compound_to_shape(&self.inner);
+        let inner_shape = ffi::cast_compound_to_shape(&self.inner);
 
-        let mut make_solid = BRepPrimAPI_MakePrism_ctor(inner_shape, &prism_vec, copy, canonize);
+        let mut make_solid =
+            ffi::BRepPrimAPI_MakePrism_ctor(inner_shape, &prism_vec, copy, canonize);
         let extruded_shape = make_solid.pin_mut().Shape();
-        let inner = TopoDS_Shape_to_owned(extruded_shape);
+        let inner = ffi::TopoDS_Shape_to_owned(extruded_shape);
 
         Shape { inner }
     }
 
     pub fn set_global_translation(&mut self, translation: DVec3) {
-        let inner = cast_compound_to_shape(&self.inner);
-        let inner = TopoDS_Shape_to_owned(inner);
+        let inner = ffi::cast_compound_to_shape(&self.inner);
+        let inner = ffi::TopoDS_Shape_to_owned(inner);
         let mut shape = Shape { inner };
 
         shape.set_global_translation(translation);
 
-        let compound = TopoDS_cast_to_compound(&shape.inner);
-        let compound = TopoDS_Compound_to_owned(compound);
+        let compound = ffi::TopoDS_cast_to_compound(&shape.inner);
+        let compound = ffi::TopoDS_Compound_to_owned(compound);
 
         self.inner = compound;
     }
@@ -615,14 +597,14 @@ pub enum FaceOrientation {
     External,
 }
 
-impl From<TopAbs_Orientation> for FaceOrientation {
-    fn from(orientation: TopAbs_Orientation) -> Self {
+impl From<ffi::TopAbs_Orientation> for FaceOrientation {
+    fn from(orientation: ffi::TopAbs_Orientation) -> Self {
         match orientation {
-            TopAbs_Orientation::TopAbs_FORWARD => Self::Forward,
-            TopAbs_Orientation::TopAbs_REVERSED => Self::Reversed,
-            TopAbs_Orientation::TopAbs_INTERNAL => Self::Internal,
-            TopAbs_Orientation::TopAbs_EXTERNAL => Self::External,
-            TopAbs_Orientation { repr } => {
+            ffi::TopAbs_Orientation::TopAbs_FORWARD => Self::Forward,
+            ffi::TopAbs_Orientation::TopAbs_REVERSED => Self::Reversed,
+            ffi::TopAbs_Orientation::TopAbs_INTERNAL => Self::Internal,
+            ffi::TopAbs_Orientation::TopAbs_EXTERNAL => Self::External,
+            ffi::TopAbs_Orientation { repr } => {
                 panic!("TopAbs_Orientation had an unrepresentable value: {repr}")
             },
         }
@@ -630,17 +612,17 @@ impl From<TopAbs_Orientation> for FaceOrientation {
 }
 
 pub struct Shell {
-    _inner: UniquePtr<TopoDS_Shell>,
+    _inner: UniquePtr<ffi::TopoDS_Shell>,
 }
 
 pub struct Solid {
-    inner: UniquePtr<TopoDS_Solid>,
+    inner: UniquePtr<ffi::TopoDS_Solid>,
 }
 
 impl Solid {
     pub fn to_shape(self) -> Shape {
-        let inner_shape = cast_solid_to_shape(&self.inner);
-        let inner = TopoDS_Shape_to_owned(inner_shape);
+        let inner_shape = ffi::cast_solid_to_shape(&self.inner);
+        let inner = ffi::TopoDS_Shape_to_owned(inner_shape);
 
         Shape { inner }
     }
@@ -650,15 +632,15 @@ impl Solid {
     // Key takeaway: Use the `SectionEdges` function to retrieve edges that were
     // the result of combining two shapes.
     pub fn fillet_edge(&self, radius: f64, edge: &Edge) -> Compound {
-        let inner_shape = cast_solid_to_shape(&self.inner);
+        let inner_shape = ffi::cast_solid_to_shape(&self.inner);
 
-        let mut make_fillet = BRepFilletAPI_MakeFillet_ctor(inner_shape);
+        let mut make_fillet = ffi::BRepFilletAPI_MakeFillet_ctor(inner_shape);
         make_fillet.pin_mut().add_edge(radius, &edge.inner);
 
         let filleted_shape = make_fillet.pin_mut().Shape();
 
-        let compund = TopoDS_cast_to_compound(filleted_shape);
-        let inner = TopoDS_Compound_to_owned(compund);
+        let compund = ffi::TopoDS_cast_to_compound(filleted_shape);
+        let inner = ffi::TopoDS_Compound_to_owned(compund);
 
         Compound { inner }
     }
@@ -666,7 +648,7 @@ impl Solid {
     // TODO(bschwind) - Accept IntoIter instead of Iterator
     pub fn loft<'a>(wires: impl Iterator<Item = &'a Wire>) -> Self {
         let is_solid = true;
-        let mut make_loft = BRepOffsetAPI_ThruSections_ctor(is_solid);
+        let mut make_loft = ffi::BRepOffsetAPI_ThruSections_ctor(is_solid);
 
         for wire in wires {
             make_loft.pin_mut().AddWire(&wire.inner);
@@ -676,18 +658,18 @@ impl Solid {
         make_loft.pin_mut().CheckCompatibility(true);
 
         let shape = make_loft.pin_mut().Shape();
-        let solid = TopoDS_cast_to_solid(shape);
-        let inner = TopoDS_Solid_to_owned(solid);
+        let solid = ffi::TopoDS_cast_to_solid(shape);
+        let inner = ffi::TopoDS_Solid_to_owned(solid);
 
         Self { inner }
     }
 
     pub fn write_stl<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
-        let inner_shape = cast_solid_to_shape(&self.inner);
+        let inner_shape = ffi::cast_solid_to_shape(&self.inner);
 
-        let mut stl_writer = StlAPI_Writer_ctor();
-        let triangulation = BRepMesh_IncrementalMesh_ctor(inner_shape, 0.001);
-        let success = write_stl(
+        let mut stl_writer = ffi::StlAPI_Writer_ctor();
+        let triangulation = ffi::BRepMesh_IncrementalMesh_ctor(inner_shape, 0.001);
+        let success = ffi::write_stl(
             stl_writer.pin_mut(),
             triangulation.Shape(),
             path.as_ref().to_string_lossy().to_string(),
@@ -701,59 +683,59 @@ impl Solid {
     }
 
     pub fn subtract(&mut self, other: &Solid) -> (Shape, Vec<Edge>) {
-        let inner_shape = cast_solid_to_shape(&self.inner);
-        let other_inner_shape = cast_solid_to_shape(&other.inner);
+        let inner_shape = ffi::cast_solid_to_shape(&self.inner);
+        let other_inner_shape = ffi::cast_solid_to_shape(&other.inner);
 
-        let mut cut_operation = BRepAlgoAPI_Cut_ctor(inner_shape, other_inner_shape);
+        let mut cut_operation = ffi::BRepAlgoAPI_Cut_ctor(inner_shape, other_inner_shape);
 
         let edge_list = cut_operation.pin_mut().SectionEdges();
-        let vec = shape_list_to_vector(edge_list);
+        let vec = ffi::shape_list_to_vector(edge_list);
 
         let mut edges = vec![];
         for shape in vec.iter() {
-            let edge = TopoDS_cast_to_edge(shape);
-            let inner = TopoDS_Edge_to_owned(edge);
+            let edge = ffi::TopoDS_cast_to_edge(shape);
+            let inner = ffi::TopoDS_Edge_to_owned(edge);
             let edge = Edge { inner };
             edges.push(edge);
         }
 
         let cut_shape = cut_operation.pin_mut().Shape();
-        let inner = TopoDS_Shape_to_owned(cut_shape);
+        let inner = ffi::TopoDS_Shape_to_owned(cut_shape);
 
         (Shape { inner }, edges)
     }
 
     pub fn union(&self, other: &Solid) -> (Shape, Vec<Edge>) {
-        let inner_shape = cast_solid_to_shape(&self.inner);
-        let other_inner_shape = cast_solid_to_shape(&other.inner);
+        let inner_shape = ffi::cast_solid_to_shape(&self.inner);
+        let other_inner_shape = ffi::cast_solid_to_shape(&other.inner);
 
-        let mut fuse_operation = BRepAlgoAPI_Fuse_ctor(inner_shape, other_inner_shape);
+        let mut fuse_operation = ffi::BRepAlgoAPI_Fuse_ctor(inner_shape, other_inner_shape);
         let edge_list = fuse_operation.pin_mut().SectionEdges();
-        let vec = shape_list_to_vector(edge_list);
+        let vec = ffi::shape_list_to_vector(edge_list);
 
         let mut edges = vec![];
         for shape in vec.iter() {
-            let edge = TopoDS_cast_to_edge(shape);
-            let inner = TopoDS_Edge_to_owned(edge);
+            let edge = ffi::TopoDS_cast_to_edge(shape);
+            let inner = ffi::TopoDS_Edge_to_owned(edge);
             let edge = Edge { inner };
             edges.push(edge);
         }
 
         let fuse_shape = fuse_operation.pin_mut().Shape();
-        let inner = TopoDS_Shape_to_owned(fuse_shape);
+        let inner = ffi::TopoDS_Shape_to_owned(fuse_shape);
 
         (Shape { inner }, edges)
     }
 }
 
 pub struct Compound {
-    inner: UniquePtr<TopoDS_Compound>,
+    inner: UniquePtr<ffi::TopoDS_Compound>,
 }
 
 impl Compound {
     pub fn clean(&mut self) -> Shape {
-        let inner = cast_compound_to_shape(&self.inner);
-        let inner = TopoDS_Shape_to_owned(inner);
+        let inner = ffi::cast_compound_to_shape(&self.inner);
+        let inner = ffi::TopoDS_Shape_to_owned(inner);
         let mut shape = Shape { inner };
 
         shape.clean();
@@ -762,38 +744,38 @@ impl Compound {
     }
 
     pub fn to_shape(self) -> Shape {
-        let inner_shape = cast_compound_to_shape(&self.inner);
-        let inner = TopoDS_Shape_to_owned(inner_shape);
+        let inner_shape = ffi::cast_compound_to_shape(&self.inner);
+        let inner = ffi::TopoDS_Shape_to_owned(inner_shape);
 
         Shape { inner }
     }
 }
 
 pub struct Shape {
-    pub(crate) inner: UniquePtr<TopoDS_Shape>,
+    pub(crate) inner: UniquePtr<ffi::TopoDS_Shape>,
 }
 
 impl Shape {
     pub fn fillet_edge(&mut self, radius: f64, edge: &Edge) {
-        let mut make_fillet = BRepFilletAPI_MakeFillet_ctor(&self.inner);
+        let mut make_fillet = ffi::BRepFilletAPI_MakeFillet_ctor(&self.inner);
         make_fillet.pin_mut().add_edge(radius, &edge.inner);
 
         let filleted_shape = make_fillet.pin_mut().Shape();
 
-        self.inner = TopoDS_Shape_to_owned(filleted_shape);
+        self.inner = ffi::TopoDS_Shape_to_owned(filleted_shape);
     }
 
     pub fn chamfer_edge(&mut self, distance: f64, edge: &Edge) {
-        let mut make_chamfer = BRepFilletAPI_MakeChamfer_ctor(&self.inner);
+        let mut make_chamfer = ffi::BRepFilletAPI_MakeChamfer_ctor(&self.inner);
         make_chamfer.pin_mut().add_edge(distance, &edge.inner);
 
         let chamfered_shape = make_chamfer.pin_mut().Shape();
 
-        self.inner = TopoDS_Shape_to_owned(chamfered_shape);
+        self.inner = ffi::TopoDS_Shape_to_owned(chamfered_shape);
     }
 
     pub fn fillet_edges<'a>(&mut self, radius: f64, edges: impl IntoIterator<Item = &'a Edge>) {
-        let mut make_fillet = BRepFilletAPI_MakeFillet_ctor(&self.inner);
+        let mut make_fillet = ffi::BRepFilletAPI_MakeFillet_ctor(&self.inner);
 
         for edge in edges.into_iter() {
             make_fillet.pin_mut().add_edge(radius, &edge.inner);
@@ -801,11 +783,11 @@ impl Shape {
 
         let filleted_shape = make_fillet.pin_mut().Shape();
 
-        self.inner = TopoDS_Shape_to_owned(filleted_shape);
+        self.inner = ffi::TopoDS_Shape_to_owned(filleted_shape);
     }
 
     pub fn chamfer_edges<'a>(&mut self, distance: f64, edges: impl IntoIterator<Item = &'a Edge>) {
-        let mut make_chamfer = BRepFilletAPI_MakeChamfer_ctor(&self.inner);
+        let mut make_chamfer = ffi::BRepFilletAPI_MakeChamfer_ctor(&self.inner);
 
         for edge in edges.into_iter() {
             make_chamfer.pin_mut().add_edge(distance, &edge.inner);
@@ -813,7 +795,7 @@ impl Shape {
 
         let chamfered_shape = make_chamfer.pin_mut().Shape();
 
-        self.inner = TopoDS_Shape_to_owned(chamfered_shape);
+        self.inner = ffi::TopoDS_Shape_to_owned(chamfered_shape);
     }
 
     /// Performs fillet of `radius` on all edges of the shape
@@ -829,104 +811,104 @@ impl Shape {
     }
 
     pub fn subtract(&mut self, other: &Solid) -> (Shape, Vec<Edge>) {
-        let other_inner_shape = cast_solid_to_shape(&other.inner);
+        let other_inner_shape = ffi::cast_solid_to_shape(&other.inner);
 
-        let mut cut_operation = BRepAlgoAPI_Cut_ctor(&self.inner, other_inner_shape);
+        let mut cut_operation = ffi::BRepAlgoAPI_Cut_ctor(&self.inner, other_inner_shape);
 
         let edge_list = cut_operation.pin_mut().SectionEdges();
-        let vec = shape_list_to_vector(edge_list);
+        let vec = ffi::shape_list_to_vector(edge_list);
 
         let mut edges = vec![];
         for shape in vec.iter() {
-            let edge = TopoDS_cast_to_edge(shape);
-            let inner = TopoDS_Edge_to_owned(edge);
+            let edge = ffi::TopoDS_cast_to_edge(shape);
+            let inner = ffi::TopoDS_Edge_to_owned(edge);
             let edge = Edge { inner };
             edges.push(edge);
         }
 
         let cut_shape = cut_operation.pin_mut().Shape();
-        let inner = TopoDS_Shape_to_owned(cut_shape);
+        let inner = ffi::TopoDS_Shape_to_owned(cut_shape);
 
         (Shape { inner }, edges)
     }
 
     // TODO(bschwind) - Deduplicate with the above function.
     pub fn subtract_shape(&mut self, other: &Shape) -> (Shape, Vec<Edge>) {
-        let mut cut_operation = BRepAlgoAPI_Cut_ctor(&self.inner, &other.inner);
+        let mut cut_operation = ffi::BRepAlgoAPI_Cut_ctor(&self.inner, &other.inner);
 
         let edge_list = cut_operation.pin_mut().SectionEdges();
-        let vec = shape_list_to_vector(edge_list);
+        let vec = ffi::shape_list_to_vector(edge_list);
 
         let mut edges = vec![];
         for shape in vec.iter() {
-            let edge = TopoDS_cast_to_edge(shape);
-            let inner = TopoDS_Edge_to_owned(edge);
+            let edge = ffi::TopoDS_cast_to_edge(shape);
+            let inner = ffi::TopoDS_Edge_to_owned(edge);
             let edge = Edge { inner };
             edges.push(edge);
         }
 
         let cut_shape = cut_operation.pin_mut().Shape();
-        let inner = TopoDS_Shape_to_owned(cut_shape);
+        let inner = ffi::TopoDS_Shape_to_owned(cut_shape);
 
         (Shape { inner }, edges)
     }
 
     pub fn read_step<P: AsRef<Path>>(path: P) -> Self {
-        let mut reader = STEPControl_Reader_ctor();
+        let mut reader = ffi::STEPControl_Reader_ctor();
         let _return_status =
-            read_step(reader.pin_mut(), path.as_ref().to_string_lossy().to_string());
-        reader.pin_mut().TransferRoots(&Message_ProgressRange_ctor());
+            ffi::read_step(reader.pin_mut(), path.as_ref().to_string_lossy().to_string());
+        reader.pin_mut().TransferRoots(&ffi::Message_ProgressRange_ctor());
 
-        let inner = one_shape(&reader);
+        let inner = ffi::one_shape(&reader);
 
         Self { inner }
     }
 
     pub fn union(&self, other: &Solid) -> (Shape, Vec<Edge>) {
-        let other_inner_shape = cast_solid_to_shape(&other.inner);
+        let other_inner_shape = ffi::cast_solid_to_shape(&other.inner);
 
-        let mut fuse_operation = BRepAlgoAPI_Fuse_ctor(&self.inner, other_inner_shape);
+        let mut fuse_operation = ffi::BRepAlgoAPI_Fuse_ctor(&self.inner, other_inner_shape);
         let edge_list = fuse_operation.pin_mut().SectionEdges();
-        let vec = shape_list_to_vector(edge_list);
+        let vec = ffi::shape_list_to_vector(edge_list);
 
         let mut edges = vec![];
         for shape in vec.iter() {
-            let edge = TopoDS_cast_to_edge(shape);
-            let inner = TopoDS_Edge_to_owned(edge);
+            let edge = ffi::TopoDS_cast_to_edge(shape);
+            let inner = ffi::TopoDS_Edge_to_owned(edge);
             let edge = Edge { inner };
             edges.push(edge);
         }
 
         let fuse_shape = fuse_operation.pin_mut().Shape();
-        let inner = TopoDS_Shape_to_owned(fuse_shape);
+        let inner = ffi::TopoDS_Shape_to_owned(fuse_shape);
 
         (Shape { inner }, edges)
     }
 
     // TODO(bschwind) - Unify this later
     pub fn union_shape(&self, other: &Shape) -> (Shape, Vec<Edge>) {
-        let mut fuse_operation = BRepAlgoAPI_Fuse_ctor(&self.inner, &other.inner);
+        let mut fuse_operation = ffi::BRepAlgoAPI_Fuse_ctor(&self.inner, &other.inner);
         let edge_list = fuse_operation.pin_mut().SectionEdges();
-        let vec = shape_list_to_vector(edge_list);
+        let vec = ffi::shape_list_to_vector(edge_list);
 
         let mut edges = vec![];
         for shape in vec.iter() {
-            let edge = TopoDS_cast_to_edge(shape);
-            let inner = TopoDS_Edge_to_owned(edge);
+            let edge = ffi::TopoDS_cast_to_edge(shape);
+            let inner = ffi::TopoDS_Edge_to_owned(edge);
             let edge = Edge { inner };
             edges.push(edge);
         }
 
         let fuse_shape = fuse_operation.pin_mut().Shape();
-        let inner = TopoDS_Shape_to_owned(fuse_shape);
+        let inner = ffi::TopoDS_Shape_to_owned(fuse_shape);
 
         (Shape { inner }, edges)
     }
 
     pub fn write_stl<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
-        let mut stl_writer = StlAPI_Writer_ctor();
-        let triangulation = BRepMesh_IncrementalMesh_ctor(&self.inner, 0.001);
-        let success = write_stl(
+        let mut stl_writer = ffi::StlAPI_Writer_ctor();
+        let triangulation = ffi::BRepMesh_IncrementalMesh_ctor(&self.inner, 0.001);
+        let success = ffi::write_stl(
             stl_writer.pin_mut(),
             triangulation.Shape(),
             path.as_ref().to_string_lossy().to_string(),
@@ -940,21 +922,21 @@ impl Shape {
     }
 
     pub fn clean(&mut self) {
-        let mut upgrader = ShapeUpgrade_UnifySameDomain_ctor(&self.inner, true, true, true);
+        let mut upgrader = ffi::ShapeUpgrade_UnifySameDomain_ctor(&self.inner, true, true, true);
         upgrader.pin_mut().AllowInternalEdges(false);
         upgrader.pin_mut().Build();
 
         let upgraded_shape = upgrader.Shape();
 
-        self.inner = TopoDS_Shape_to_owned(upgraded_shape);
+        self.inner = ffi::TopoDS_Shape_to_owned(upgraded_shape);
     }
 
     pub fn set_global_translation(&mut self, translation: DVec3) {
-        let mut transform = new_transform();
+        let mut transform = ffi::new_transform();
         let translation_vec = make_vec(translation);
         transform.pin_mut().set_translation_vec(&translation_vec);
 
-        let location = TopLoc_Location_from_transform(&transform);
+        let location = ffi::TopLoc_Location_from_transform(&transform);
 
         self.inner.pin_mut().set_global_translation(&location, false);
     }
@@ -965,33 +947,33 @@ impl Shape {
     }
 
     pub fn edges(&self) -> EdgeIterator {
-        let explorer = TopExp_Explorer_ctor(&self.inner, TopAbs_ShapeEnum::TopAbs_EDGE);
+        let explorer = ffi::TopExp_Explorer_ctor(&self.inner, ffi::TopAbs_ShapeEnum::TopAbs_EDGE);
 
         EdgeIterator { explorer }
     }
 
     pub fn faces(&self) -> FaceIterator {
-        let explorer = TopExp_Explorer_ctor(&self.inner, TopAbs_ShapeEnum::TopAbs_FACE);
+        let explorer = ffi::TopExp_Explorer_ctor(&self.inner, ffi::TopAbs_ShapeEnum::TopAbs_FACE);
 
         FaceIterator { explorer }
     }
 
     pub fn faces_along_ray(&self, ray_start: DVec3, ray_dir: DVec3) -> Vec<(Face, DVec3)> {
-        let mut intersector = BRepIntCurveSurface_Inter_ctor();
+        let mut intersector = ffi::BRepIntCurveSurface_Inter_ctor();
         let tolerance = 0.0001;
         intersector.pin_mut().Init(
             &self.inner,
-            &gp_Lin_ctor(&make_point(ray_start), &make_dir(ray_dir)),
+            &ffi::gp_Lin_ctor(&make_point(ray_start), &make_dir(ray_dir)),
             tolerance,
         );
 
         let mut results = vec![];
 
         while intersector.More() {
-            let face = BRepIntCurveSurface_Inter_face(&intersector);
-            let point = BRepIntCurveSurface_Inter_point(&intersector);
+            let face = ffi::BRepIntCurveSurface_Inter_face(&intersector);
+            let point = ffi::BRepIntCurveSurface_Inter_point(&intersector);
 
-            let face = Face { inner: TopoDS_Face_to_owned(&face) };
+            let face = Face { inner: ffi::TopoDS_Face_to_owned(&face) };
 
             results.push((face, dvec3(point.X(), point.Y(), point.Z())));
 
@@ -1003,16 +985,16 @@ impl Shape {
 }
 
 struct Mesher {
-    inner: UniquePtr<BRepMesh_IncrementalMesh>,
+    inner: UniquePtr<ffi::BRepMesh_IncrementalMesh>,
 }
 
 impl Mesher {
     fn new(shape: &Shape) -> Self {
-        let inner = BRepMesh_IncrementalMesh_ctor(&shape.inner, 0.01);
+        let inner = ffi::BRepMesh_IncrementalMesh_ctor(&shape.inner, 0.01);
 
         if !inner.IsDone() {
             // TODO(bschwind) - Add proper Error type and return Result.
-            panic!("Call to BRepMesh_IncrementalMesh_ctor failed");
+            panic!("Call to ffi::BRepMesh_IncrementalMesh_ctor failed");
         }
 
         Self { inner }
@@ -1024,15 +1006,16 @@ impl Mesher {
         let mut normals = vec![];
         let mut indices = vec![];
 
-        let triangulated_shape = TopoDS_Shape_to_owned(self.inner.pin_mut().Shape());
+        let triangulated_shape = ffi::TopoDS_Shape_to_owned(self.inner.pin_mut().Shape());
         let triangulated_shape = Shape { inner: triangulated_shape };
 
         for face in triangulated_shape.faces() {
-            let mut location = TopLoc_Location_ctor();
+            let mut location = ffi::TopLoc_Location_ctor();
 
-            let triangulation_handle = BRep_Tool_Triangulation(&face.inner, location.pin_mut());
+            let triangulation_handle =
+                ffi::BRep_Tool_Triangulation(&face.inner, location.pin_mut());
 
-            let Ok(triangulation) = Handle_Poly_Triangulation_Get(&triangulation_handle) else {
+            let Ok(triangulation) = ffi::Handle_Poly_Triangulation_Get(&triangulation_handle) else {
                 // TODO(bschwind) - Do better error handling, use Results.
                 println!("Encountered a face with no triangulation");
                 continue;
@@ -1042,8 +1025,8 @@ impl Mesher {
             let face_point_count = triangulation.NbNodes();
 
             for i in 1..=face_point_count {
-                let mut point = Poly_Triangulation_Node(triangulation, i);
-                point.pin_mut().Transform(&TopLoc_Location_Transformation(&location));
+                let mut point = ffi::Poly_Triangulation_Node(triangulation, i);
+                point.pin_mut().Transform(&ffi::TopLoc_Location_Transformation(&location));
                 vertices.push(dvec3(point.X(), point.Y(), point.Z()));
             }
 
@@ -1054,7 +1037,7 @@ impl Mesher {
             let mut v_max = f64::NEG_INFINITY;
 
             for i in 1..=(face_point_count) {
-                let uv = Poly_Triangulation_UV(triangulation, i);
+                let uv = ffi::Poly_Triangulation_UV(triangulation, i);
                 let (u, v) = (uv.X(), uv.Y());
 
                 u_min = u_min.min(u);
@@ -1078,14 +1061,18 @@ impl Mesher {
 
             // Add in the normals.
             // TODO(bschwind) - Use `location` to transform the normals.
-            let mut poly_connect = Poly_Connect_ctor(&triangulation_handle);
-            let mut normal_array = TColgp_Array1OfDir_ctor(0, face_point_count);
+            let mut poly_connect = ffi::Poly_Connect_ctor(&triangulation_handle);
+            let mut normal_array = ffi::TColgp_Array1OfDir_ctor(0, face_point_count);
 
-            triangulated_shape_normal(&face.inner, poly_connect.pin_mut(), normal_array.pin_mut());
+            ffi::triangulated_shape_normal(
+                &face.inner,
+                poly_connect.pin_mut(),
+                normal_array.pin_mut(),
+            );
 
             // TODO(bschwind) - Why do we start at 1 here?
             for i in 1..(normal_array.Length() as usize) {
-                let normal = TColgp_Array1OfDir_Value(&normal_array, i as i32);
+                let normal = ffi::TColgp_Array1OfDir_Value(&normal_array, i as i32);
                 normals.push(dvec3(normal.X(), normal.Y(), normal.Z()));
             }
 
@@ -1118,7 +1105,7 @@ pub struct Mesh {
 }
 
 pub struct EdgeIterator {
-    explorer: UniquePtr<TopExp_Explorer>,
+    explorer: UniquePtr<ffi::TopExp_Explorer>,
 }
 
 impl Iterator for EdgeIterator {
@@ -1126,8 +1113,8 @@ impl Iterator for EdgeIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.explorer.More() {
-            let edge = TopoDS_cast_to_edge(self.explorer.Current());
-            let inner = TopoDS_Edge_to_owned(edge);
+            let edge = ffi::TopoDS_cast_to_edge(self.explorer.Current());
+            let inner = ffi::TopoDS_Edge_to_owned(edge);
 
             self.explorer.pin_mut().Next();
 
@@ -1139,7 +1126,7 @@ impl Iterator for EdgeIterator {
 }
 
 pub struct FaceIterator {
-    explorer: UniquePtr<TopExp_Explorer>,
+    explorer: UniquePtr<ffi::TopExp_Explorer>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -1186,8 +1173,8 @@ impl Iterator for FaceIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.explorer.More() {
-            let face = TopoDS_cast_to_face(self.explorer.Current());
-            let inner = TopoDS_Face_to_owned(face);
+            let face = ffi::TopoDS_cast_to_face(self.explorer.Current());
+            let inner = ffi::TopoDS_Face_to_owned(face);
 
             self.explorer.pin_mut().Next();
 


### PR DESCRIPTION
Follow-up to https://github.com/bschwind/opencascade-rs/pull/81#issuecomment-1635870543

Sorry for the churn, but sooner we do this the better I guess.