### PR TITLE
Add an Angle and RVec (rotation vector) type

### DIFF
--- a/crates/opencascade/examples/keycap.rs
+++ b/crates/opencascade/examples/keycap.rs
@@ -2,6 +2,7 @@
 // https://github.com/cubiq/OPK/blob/53f9d6a4123b0f309f87158115c83d19811b3484/opk.py
 use glam::dvec3;
 use opencascade::{
+    angle::{RVec, ToAngle},
     primitives::{Direction, Face, Solid},
     workplane::Workplane,
 };
@@ -13,7 +14,7 @@ pub fn main() {
     let keycap_unit_size_x = 1.0;
     let keycap_unit_size_y = 1.0;
     let height = 16.0;
-    let angle = 13.0;
+    let angle = 13.0.degrees();
     let depth: f64 = 2.8;
     let thickness: f64 = 1.5;
     let base = 18.2;
@@ -57,7 +58,7 @@ pub fn main() {
 
     let scoop = if convex {
         let scoop = Workplane::yz()
-            .transformed(dvec3(0.0, height - 2.1, -bx / 2.0), dvec3(0.0, 0.0, angle))
+            .transformed(dvec3(0.0, height - 2.1, -bx / 2.0), RVec::z(angle))
             .sketch()
             .move_to(-by / 2.0, -1.0)
             .three_point_arc((0.0, 2.0), (by / 2.0, -1.0))
@@ -69,7 +70,7 @@ pub fn main() {
         scoop.extrude(dvec3(bx, 0.0, 0.0))
     } else {
         let scoop_right = Workplane::yz()
-            .transformed(dvec3(0.0, height, bx / 2.0), dvec3(0.0, 0.0, angle))
+            .transformed(dvec3(0.0, height, bx / 2.0), RVec::z(angle))
             .sketch()
             .move_to(-by / 2.0 + 2.0, 0.0)
             .three_point_arc((0.0, (-depth + 1.5).min(-0.1)), (by / 2.0 - 2.0, 0.0))
@@ -78,7 +79,7 @@ pub fn main() {
             .close();
 
         let scoop_mid = Workplane::yz()
-            .transformed(dvec3(0.0, height, 0.0), dvec3(0.0, 0.0, angle))
+            .transformed(dvec3(0.0, height, 0.0), RVec::z(angle))
             .sketch()
             .move_to(-by / 2.0 - 2.0, -0.5)
             .three_point_arc((0.0, -depth), (by / 2.0 + 2.0, -0.5))
@@ -87,7 +88,7 @@ pub fn main() {
             .close();
 
         let scoop_left = Workplane::yz()
-            .transformed(dvec3(0.0, height, -bx / 2.0), dvec3(0.0, 0.0, angle))
+            .transformed(dvec3(0.0, height, -bx / 2.0), RVec::z(angle))
             .sketch()
             .move_to(-by / 2.0 + 2.0, 0.0)
             .three_point_arc((0.0, (-depth + 1.5).min(-0.1)), (by / 2.0 - 2.0, 0.0))
@@ -108,10 +109,7 @@ pub fn main() {
         .rect(bx - thickness * 3.0, by - thickness * 3.0);
 
     let shell_top = Workplane::xy()
-        .transformed(
-            dvec3(0.0, 0.0, (height / 4.0) + height - height / 4.0 - 4.5),
-            dvec3(angle, 0.0, 0.0),
-        )
+        .transformed(dvec3(0.0, 0.0, (height / 4.0) + height - height / 4.0 - 4.5), RVec::x(angle))
         .rect(tx - thickness * 2.0 + 0.5, ty - thickness * 2.0 + 0.5);
 
     let shell = Solid::loft([&shell_bottom, &shell_mid, &shell_top].into_iter());

--- a/crates/opencascade/src/angle.rs
+++ b/crates/opencascade/src/angle.rs
@@ -1,0 +1,106 @@
+use glam::{dvec3, DVec3};
+use std::ops::{Div, Mul};
+
+#[derive(Debug, Copy, Clone)]
+pub enum Angle {
+    Radians(f64),
+    Degrees(f64),
+}
+
+impl Angle {
+    pub fn radians(&self) -> f64 {
+        match self {
+            Self::Radians(r) => *r,
+            Self::Degrees(d) => (d * std::f64::consts::PI) / 180.0,
+        }
+    }
+
+    pub fn degrees(&self) -> f64 {
+        match self {
+            Self::Radians(r) => (r * 180.0) / std::f64::consts::PI,
+            Self::Degrees(d) => *d,
+        }
+    }
+}
+
+impl Mul<f64> for Angle {
+    type Output = Angle;
+
+    fn mul(self, multiplier: f64) -> Self::Output {
+        match self {
+            Self::Radians(angle) => Self::Radians(angle * multiplier),
+            Self::Degrees(angle) => Self::Degrees(angle * multiplier),
+        }
+    }
+}
+
+impl Div<f64> for Angle {
+    type Output = Angle;
+
+    fn div(self, divisor: f64) -> Self::Output {
+        match self {
+            Self::Radians(angle) => Self::Radians(angle / divisor),
+            Self::Degrees(angle) => Self::Degrees(angle / divisor),
+        }
+    }
+}
+
+pub trait ToAngle {
+    fn degrees(&self) -> Angle;
+    fn radians(&self) -> Angle;
+}
+
+impl ToAngle for f64 {
+    fn degrees(&self) -> Angle {
+        Angle::Degrees(*self)
+    }
+
+    fn radians(&self) -> Angle {
+        Angle::Radians(*self)
+    }
+}
+
+impl ToAngle for u64 {
+    fn degrees(&self) -> Angle {
+        Angle::Degrees(*self as f64)
+    }
+
+    fn radians(&self) -> Angle {
+        Angle::Radians(*self as f64)
+    }
+}
+
+/// Represents rotation on the X, Y, and Z axes. Also known
+/// as Euler angle representation.
+#[derive(Debug, Copy, Clone)]
+pub struct RVec {
+    pub x: Angle,
+    pub y: Angle,
+    pub z: Angle,
+}
+
+impl RVec {
+    pub fn radians(&self) -> DVec3 {
+        dvec3(self.x.radians(), self.y.radians(), self.z.radians())
+    }
+
+    pub fn degrees(&self) -> DVec3 {
+        dvec3(self.x.degrees(), self.y.degrees(), self.z.degrees())
+    }
+
+    pub fn x(x: Angle) -> Self {
+        RVec { x, y: 0.degrees(), z: 0.degrees() }
+    }
+
+    pub fn y(y: Angle) -> Self {
+        RVec { x: 0.degrees(), y, z: 0.degrees() }
+    }
+
+    pub fn z(z: Angle) -> Self {
+        RVec { x: 0.degrees(), y: 0.degrees(), z }
+    }
+}
+
+pub fn rvec(x: Angle, y: Angle, z: Angle) -> RVec {
+    RVec { x, y, z }
+}

--- a/crates/opencascade/src/angle.rs
+++ b/crates/opencascade/src/angle.rs
@@ -50,23 +50,13 @@ pub trait ToAngle {
     fn radians(&self) -> Angle;
 }
 
-impl ToAngle for f64 {
+impl<T: Into<f64> + Copy> ToAngle for T {
     fn degrees(&self) -> Angle {
-        Angle::Degrees(*self)
+        Angle::Degrees((*self).into())
     }
 
     fn radians(&self) -> Angle {
-        Angle::Radians(*self)
-    }
-}
-
-impl ToAngle for u64 {
-    fn degrees(&self) -> Angle {
-        Angle::Degrees(*self as f64)
-    }
-
-    fn radians(&self) -> Angle {
-        Angle::Radians(*self as f64)
+        Angle::Radians((*self).into())
     }
 }
 

--- a/crates/opencascade/src/lib.rs
+++ b/crates/opencascade/src/lib.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 pub mod adhoc;
+pub mod angle;
 pub mod primitives;
 pub mod workplane;
 

--- a/crates/opencascade/src/workplane.rs
+++ b/crates/opencascade/src/workplane.rs
@@ -1,4 +1,7 @@
-use crate::primitives::{Edge, Wire};
+use crate::{
+    angle::{Angle, RVec},
+    primitives::{Edge, Wire},
+};
 use glam::{dvec3, DAffine3, DMat3, DVec3, EulerRot};
 
 #[derive(Debug, Copy, Clone)]
@@ -97,11 +100,9 @@ impl Workplane {
     }
 
     // TODO(bschwind) - Test this.
-    pub fn set_rotation(&mut self, (rot_x, rot_y, rot_z): (f64, f64, f64)) {
-        let rot_x = rot_x * std::f64::consts::PI / 180.0;
-        let rot_y = rot_y * std::f64::consts::PI / 180.0;
-        let rot_z = rot_z * std::f64::consts::PI / 180.0;
-        let rotation_matrix = DMat3::from_euler(EulerRot::XYZ, rot_x, rot_y, rot_z);
+    pub fn set_rotation(&mut self, (rot_x, rot_y, rot_z): (Angle, Angle, Angle)) {
+        let rotation_matrix =
+            DMat3::from_euler(EulerRot::XYZ, rot_x.radians(), rot_y.radians(), rot_z.radians());
 
         let translation = self.transform.translation;
 
@@ -117,11 +118,9 @@ impl Workplane {
         self.set_translation(translation);
     }
 
-    pub fn rotate_by(&mut self, (rot_x, rot_y, rot_z): (f64, f64, f64)) {
-        let rot_x = rot_x * std::f64::consts::PI / 180.0;
-        let rot_y = rot_y * std::f64::consts::PI / 180.0;
-        let rot_z = rot_z * std::f64::consts::PI / 180.0;
-        let rotation_matrix = DMat3::from_euler(EulerRot::XYZ, rot_x, rot_y, rot_z);
+    pub fn rotate_by(&mut self, (rot_x, rot_y, rot_z): (Angle, Angle, Angle)) {
+        let rotation_matrix =
+            DMat3::from_euler(EulerRot::XYZ, rot_x.radians(), rot_y.radians(), rot_z.radians());
 
         let translation = self.transform.translation;
 
@@ -145,7 +144,7 @@ impl Workplane {
         self.transform.translation += offset;
     }
 
-    pub fn transformed(&self, offset: DVec3, rotate: DVec3) -> Self {
+    pub fn transformed(&self, offset: DVec3, rotate: RVec) -> Self {
         let mut new = self.clone();
         let new_origin = new.to_world_pos(offset);
 
@@ -163,7 +162,7 @@ impl Workplane {
         new
     }
 
-    pub fn rotated(&self, rotate: DVec3) -> Self {
+    pub fn rotated(&self, rotate: RVec) -> Self {
         let mut new = self.clone();
         new.rotate_by((rotate.x, rotate.y, rotate.z));
 

--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use glam::{dvec3, vec3, DVec3, Mat4};
 use opencascade::{
+    angle::{RVec, ToAngle},
     primitives::{Face, Shape, Solid, Wire},
     workplane::Workplane,
 };
@@ -235,7 +236,7 @@ fn keycap() -> Shape {
     let keycap_unit_size_x = 1.0;
     let keycap_unit_size_y = 1.0;
     let height = 16.0;
-    let angle = 13.0;
+    let angle = 13.0.degrees();
     let depth: f64 = 2.8;
     let thickness: f64 = 1.5;
     let base = 18.2;
@@ -278,7 +279,7 @@ fn keycap() -> Shape {
 
     let scoop = if convex {
         let scoop = Workplane::yz()
-            .transformed(dvec3(0.0, height - 2.1, -bx / 2.0), dvec3(0.0, 0.0, angle))
+            .transformed(dvec3(0.0, height - 2.1, -bx / 2.0), RVec::z(angle))
             .sketch()
             .move_to(-by / 2.0, -1.0)
             .three_point_arc((0.0, 2.0), (by / 2.0, -1.0))
@@ -290,7 +291,7 @@ fn keycap() -> Shape {
         scoop.extrude(dvec3(bx, 0.0, 0.0))
     } else {
         let scoop_right = Workplane::yz()
-            .transformed(dvec3(0.0, height, bx / 2.0), dvec3(0.0, 0.0, angle))
+            .transformed(dvec3(0.0, height, bx / 2.0), RVec::z(angle))
             .sketch()
             .move_to(-by / 2.0 + 2.0, 0.0)
             .three_point_arc((0.0, (-depth + 1.5).min(-0.1)), (by / 2.0 - 2.0, 0.0))
@@ -299,7 +300,7 @@ fn keycap() -> Shape {
             .close();
 
         let scoop_mid = Workplane::yz()
-            .transformed(dvec3(0.0, height, 0.0), dvec3(0.0, 0.0, angle))
+            .transformed(dvec3(0.0, height, 0.0), RVec::z(angle))
             .sketch()
             .move_to(-by / 2.0 - 2.0, -0.5)
             .three_point_arc((0.0, -depth), (by / 2.0 + 2.0, -0.5))
@@ -308,7 +309,7 @@ fn keycap() -> Shape {
             .close();
 
         let scoop_left = Workplane::yz()
-            .transformed(dvec3(0.0, height, -bx / 2.0), dvec3(0.0, 0.0, angle))
+            .transformed(dvec3(0.0, height, -bx / 2.0), RVec::z(angle))
             .sketch()
             .move_to(-by / 2.0 + 2.0, 0.0)
             .three_point_arc((0.0, (-depth + 1.5).min(-0.1)), (by / 2.0 - 2.0, 0.0))
@@ -325,11 +326,11 @@ fn keycap() -> Shape {
     let shell_bottom = Workplane::xy().rect(bx - thickness * 2.0, by - thickness * 2.0);
 
     let shell_mid = Workplane::xy()
-        .transformed(dvec3(0.0, 0.0, height / 4.0), dvec3(0.0, 0.0, 0.0))
+        .translated(dvec3(0.0, 0.0, height / 4.0))
         .rect(bx - thickness * 3.0, by - thickness * 3.0);
 
     let shell_top = Workplane::xy()
-        .transformed(dvec3(0.0, 0.0, height - height / 4.0 - 4.5), dvec3(angle, 0.0, 0.0))
+        .transformed(dvec3(0.0, 0.0, height - height / 4.0 - 4.5), RVec::x(angle))
         .rect(tx - thickness * 2.0 + 0.5, ty - thickness * 2.0 + 0.5);
 
     let shell = Solid::loft([&shell_bottom, &shell_mid, &shell_top].into_iter());


### PR DESCRIPTION
This is _one_ possible implementation for more strongly-typed angles. Spawned from [this discussion](https://github.com/bschwind/opencascade-rs/pull/76#discussion_r1261175426)

The main goals are:

* Calling code should always indicate the unit of rotation (radians vs. degrees vs. something else)
* The called code (the OpenCascade bindings) should also explicitly mention which rotation unit it desires when passing an angle to OpenCascade.
* The calling code should be ergonomic (easy to construct, easy to read, terse but not to the point where it hurts readability)

I think what we have here so far is nice, but I'm open to suggestions if we want to make it more Rust-y with new types and `impl From<_>` signatures on functions which take angles.