### PR TITLE
Extract `occt-sys` crate (repository) out of `opencascade-sys`

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,21 +16,8 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v2
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache Rust Dependencies
+        uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,21 +15,8 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Cache cargo registry
-        uses: actions/cache@v2
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v2
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache Rust Dependencies
+        uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "crates/opencascade-sys/OCCT"]
-	path = crates/opencascade-sys/OCCT
+	path = crates/occt-sys/OCCT
 	url = https://github.com/Open-Cascade-SAS/OCCT.git

--- a/crates/occt-sys/Cargo.toml
+++ b/crates/occt-sys/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "occt-sys"
+description = "Static build of the C++ OpenCascade CAD Kernel for use as a Rust dependency"
+authors = ["Brian Schwind <brianmschwind@gmail.com>", "Matěj Laitl <matej@laitl.cz>"]
+license = "LGPL-2.1"
+version = "0.1.0"
+edition = "2021"
+repository = "https://github.com/bschwind/opencascade-rs"
+
+# Desperately trying to reduce the crate size here...
+exclude = [
+    "OCCT/adm/*",
+    "OCCT/data/*",
+    "OCCT/dox/*",
+    "OCCT/samples/*",
+    "OCCT/src/AdvApp2Var/*",
+    "OCCT/src/AIS/*",
+    "OCCT/src/AppCont/*",
+    "OCCT/src/BRepTest/*",
+    "OCCT/src/Draw/*",
+    "OCCT/src/Graphic3d/*",
+    "OCCT/src/HLRBRep/*",
+    "OCCT/src/IFSelect/*",
+    "OCCT/src/IGESAppli/*",
+    "OCCT/src/IGESData/*",
+    "OCCT/src/IGESDimen/*",
+    "OCCT/src/IGESDraw/*",
+    "OCCT/src/IGESGeom/*",
+    "OCCT/src/IGESSolid/*",
+    "OCCT/src/MeshVS/*",
+    "OCCT/src/OpenGl/*",
+    "OCCT/src/PrsDim/*",
+    "OCCT/src/QABugs/*",
+    "OCCT/src/Resource/*",
+    "OCCT/src/SelectMgr/*",
+    "OCCT/src/Shaders/*",
+    "OCCT/src/StepVisual/*",
+    "OCCT/src/TDataStd/*",
+    "OCCT/src/Textures/*",
+    "OCCT/src/ViewerTest/*",
+    "OCCT/src/Vrml/*",
+    "OCCT/src/VrmlData/*",
+    "OCCT/src/XCAFDoc/*",
+    "OCCT/src/XDEDRAW/*",
+    "OCCT/tests/*",
+    "OCCT/tools/*",
+]
+
+[dependencies]
+
+[build-dependencies]
+cmake = "0.1"

--- a/crates/occt-sys/build.rs
+++ b/crates/occt-sys/build.rs
@@ -1,0 +1,32 @@
+const LIB_DIR: &str = "lib";
+const INCLUDE_DIR: &str = "include";
+
+fn main() {
+    let dst = cmake::Config::new("OCCT")
+        .define("BUILD_LIBRARY_TYPE", "Static")
+        .define("BUILD_MODULE_Draw", "FALSE")
+        .define("USE_OPENGL", "FALSE")
+        .define("USE_GLES2", "FALSE")
+        .define("USE_D3D", "FALSE")
+        .define("USE_VTK", "FALSE")
+        .define("USE_TCL", "FALSE")
+        .define("USE_XLIB", "FALSE")
+        .define("USE_FREETYPE", "FALSE")
+        .define("USE_FREEIMAGE", "FALSE")
+        .define("USE_OPENVR", "FALSE")
+        .define("USE_FFMPEG", "FALSE")
+        .define("INSTALL_DIR_LIB", LIB_DIR)
+        .define("INSTALL_DIR_INCLUDE", INCLUDE_DIR)
+        .build();
+
+    println!(
+        "cargo:rustc-env=OCCT_LIB_PATH={}",
+        dst.join(LIB_DIR).to_str().expect("path is valid Unicode")
+    );
+    println!(
+        "cargo:rustc-env=OCCT_INCLUDE_PATH={}",
+        dst.join(INCLUDE_DIR)
+            .to_str()
+            .expect("path is valid Unicode")
+    );
+}

--- a/crates/occt-sys/build.rs
+++ b/crates/occt-sys/build.rs
@@ -25,8 +25,6 @@ fn main() {
     );
     println!(
         "cargo:rustc-env=OCCT_INCLUDE_PATH={}",
-        dst.join(INCLUDE_DIR)
-            .to_str()
-            .expect("path is valid Unicode")
+        dst.join(INCLUDE_DIR).to_str().expect("path is valid Unicode")
     );
 }

--- a/crates/occt-sys/examples/print_paths.rs
+++ b/crates/occt-sys/examples/print_paths.rs
@@ -1,0 +1,9 @@
+use occt_sys::{occt_include_path, occt_lib_path};
+
+fn main() {
+    println!("occt_lib_path: {}", occt_lib_path().to_str().unwrap());
+    println!(
+        "occt_include_path: {}",
+        occt_include_path().to_str().unwrap()
+    );
+}

--- a/crates/occt-sys/examples/print_paths.rs
+++ b/crates/occt-sys/examples/print_paths.rs
@@ -2,8 +2,5 @@ use occt_sys::{occt_include_path, occt_lib_path};
 
 fn main() {
     println!("occt_lib_path: {}", occt_lib_path().to_str().unwrap());
-    println!(
-        "occt_include_path: {}",
-        occt_include_path().to_str().unwrap()
-    );
+    println!("occt_include_path: {}", occt_include_path().to_str().unwrap());
 }

--- a/crates/occt-sys/src/lib.rs
+++ b/crates/occt-sys/src/lib.rs
@@ -1,0 +1,16 @@
+use std::path::Path;
+
+/// Get path to OCCT library directory with built static libraries. To be used in build scripts
+/// with the `cargo:rustc-link-search` command.
+///
+/// Only valid during build (`cargo clean` removes these files).
+pub fn occt_lib_path() -> &'static Path {
+    Path::new(env!("OCCT_LIB_PATH"))
+}
+
+/// Get path to OCCT header files.
+///
+/// Only valid during build (`cargo clean` removes these files).
+pub fn occt_include_path() -> &'static Path {
+    Path::new(env!("OCCT_INCLUDE_PATH"))
+}

--- a/crates/opencascade-sys/Cargo.toml
+++ b/crates/opencascade-sys/Cargo.toml
@@ -7,48 +7,10 @@ version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/bschwind/opencascade-rs"
 
-# Desperately trying to reduce the crate size here...
-exclude = [
-    "OCCT/adm/*",
-    "OCCT/data/*",
-    "OCCT/dox/*",
-    "OCCT/samples/*",
-    "OCCT/src/AdvApp2Var/*",
-    "OCCT/src/AIS/*",
-    "OCCT/src/AppCont/*",
-    "OCCT/src/BRepTest/*",
-    "OCCT/src/Draw/*",
-    "OCCT/src/Graphic3d/*",
-    "OCCT/src/HLRBRep/*",
-    "OCCT/src/IFSelect/*",
-    "OCCT/src/IGESAppli/*",
-    "OCCT/src/IGESData/*",
-    "OCCT/src/IGESDimen/*",
-    "OCCT/src/IGESDraw/*",
-    "OCCT/src/IGESGeom/*",
-    "OCCT/src/IGESSolid/*",
-    "OCCT/src/MeshVS/*",
-    "OCCT/src/OpenGl/*",
-    "OCCT/src/PrsDim/*",
-    "OCCT/src/QABugs/*",
-    "OCCT/src/Resource/*",
-    "OCCT/src/SelectMgr/*",
-    "OCCT/src/Shaders/*",
-    "OCCT/src/StepVisual/*",
-    "OCCT/src/TDataStd/*",
-    "OCCT/src/Textures/*",
-    "OCCT/src/ViewerTest/*",
-    "OCCT/src/Vrml/*",
-    "OCCT/src/VrmlData/*",
-    "OCCT/src/XCAFDoc/*",
-    "OCCT/src/XDEDRAW/*",
-    "OCCT/tests/*",
-    "OCCT/tools/*",
-]
-
 [dependencies]
 cxx = "1"
 
 [build-dependencies]
 cmake = "0.1"
 cxx-build = "1"
+occt-sys = { path = "../occt-sys" }

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -1,26 +1,11 @@
+use occt_sys::{occt_include_path, occt_lib_path};
+
 fn main() {
     let target = std::env::var("TARGET").expect("No TARGET environment variable defined");
     let is_windows = target.to_lowercase().contains("windows");
     let is_windows_gnu = target.to_lowercase().contains("windows-gnu");
 
-    let dst = cmake::Config::new("OCCT")
-        .define("BUILD_LIBRARY_TYPE", "Static")
-        .define("BUILD_MODULE_Draw", "FALSE")
-        .define("USE_OPENGL", "FALSE")
-        .define("USE_GLES2", "FALSE")
-        .define("USE_D3D", "FALSE")
-        .define("USE_VTK", "FALSE")
-        .define("USE_TCL", "FALSE")
-        .define("USE_XLIB", "FALSE")
-        .define("USE_FREETYPE", "FALSE")
-        .define("USE_FREEIMAGE", "FALSE")
-        .define("USE_OPENVR", "FALSE")
-        .define("USE_FFMPEG", "FALSE")
-        .define("INSTALL_DIR_LIB", "lib")
-        .define("INSTALL_DIR_INCLUDE", "include")
-        .build();
-
-    println!("cargo:rustc-link-search=native={}", dst.join("lib").display());
+    println!("cargo:rustc-link-search=native={}", occt_lib_path().to_str().unwrap());
     println!("cargo:rustc-link-lib=static=TKMath");
     println!("cargo:rustc-link-lib=static=TKernel");
     println!("cargo:rustc-link-lib=static=TKFeat");
@@ -60,7 +45,7 @@ fn main() {
         .cpp(true)
         .flag_if_supported("-std=c++11")
         .define("_USE_MATH_DEFINES", "TRUE")
-        .include(format!("{}", dst.join("include").display()))
+        .include(occt_include_path())
         .include("include")
         .compile("wrapper");
 

--- a/docs/writing_bindings.md
+++ b/docs/writing_bindings.md
@@ -10,9 +10,9 @@ For that we use [CXX](https://cxx.rs/), by dtolnay. CXX itself is also somewhat 
 
 ### `build.rs`
 
-At the very bottom, we have the [opencascade-sys crate](../crates/opencascade-sys), which includes the OpenCascade source code in the [OCCT directory](../crates/opencascade-sys/OCCT).
+At the very bottom, we have the [occt-sys crate](../crates/occt-sys/), which builds OpenCascade C++ project statically without any modifications.
 
-This sys crate has a [build.rs](../crates/opencascade-sys/build.rs) file which calls out to `cmake` to configure and build the project. I've tried to disable as many features as possible which are unrelated to model building (such as FFMPEG, OpenGL, Tcl, basically anything related to visualization or infrastructure as we'll be building that ourselves in Rust).
+Right above this is [opencascade-sys crate](../crates/opencascade-sys), which has a [build.rs](../crates/opencascade-sys/build.rs) file with necessary `cxx` infrastructure to compile its wrapper and C++ bindings to OpenCascade.
 
 In the theme of keeping it minimal, the OpenCascade libraries we statically link to are all explicitly laid out with `cargo:rustc-link-lib=static=LIB_NAME_HERE` cargo directives.
 


### PR DESCRIPTION
The `opencascade-sys` crate currently does basically 2 things:
1. compiles vanilla OpenCascade C++ (OCCT) using `cmake`
2. builds the Rust binding using `cxx` magic (has the Rust and C++ generated parts)

Step 1 takes 30 minutes on CI and 5 minutes on my laptop, step 2 takes less than a minute on CI and seconds on my laptop.

Whenever the bindings (Rust or .hpp file) change, whole `opencascade-sys` needs to be rebuilt. OpenCascade cmake build does support incremental compilation (`cmake` is super quick if you run in the the same build directory second time), but `cargo` likes to change the build directory (`target/debug/build/occt-sys-<hash>`), so we end up recompiling OpenCascade more often than not.

Resolve this by extracting part 1. into a separate crate, named `occt-sys` (**O**pen**C**as**c**ade **T**echnology, after upstream repo name). `occt-sys` does the static build of OpenCascade and nothing extra: no bindings, doesn't even tell cargo to link its libraries.

~This PR goes even **one step further**: it extracts `occt-sys` into its own _repository_ (not just another workspace crate).~
~The second part of this PR is therefore in https://github.com/tonarino/occt-sys/pull/1 (let's keep the high-level discussion here). ~

~This part is up for discussion. Rationale:~
- ~(biggest and triggering reason): https://github.com/Swatinem/rust-cache only caches the *dependencies*. With `occt-sys` in a separate repo, `opencascade-rs` CI runs now take a couple of minutes rather than half an hour.~
- ~`opencasdar-rs` would no longer have a git submodule, simplifying setup a tiny bit (cargo handles submodules well when fetching git dependencies)~
- ~`occt-sys` is very simple an unopinionated, shall be reusable as a dependency for other Rust projects that want static OpenCascade build.~
- ~When `occt-sys` has multiple versions (its versioning scheme could even track the upstream OCCT version), `opencascade-rs` would be free to choose what version it wants.~