### PR TITLE
Using installed version OpenCASCADE

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ There are other benefits:
 * The `OCCT` codebase is included as a git submodule. Clone the repo with the `--recursive` flag, or use `git submodule update --init` to fetch the submodule.
 * `cargo build --release`
 
+### Using pre-installed OpenCASCADE
+
+If you have `OCCT` library already installed via package manager you may use it to save huge amout of building time. By default `builtin` feature is enabled which means compiling OCCT from embedded sources. You can disable it via command line or using manifest:
+
+`cargo build --no-default-features`
+
+```
+[dependencies]
+opencascade = { version = "0.1", default-features = false, features = [] }
+```
+
+NOTE: If you have installed `OCCT` manually you may need specify path to it via `DEP_OCCT_ROOT` environment variable. Specified root directory usually expected contains `include` and `lib` directories.
+
 ## Run Examples
 
 * `cargo run --release --example bottle`

--- a/README.md
+++ b/README.md
@@ -48,16 +48,18 @@ There are other benefits:
 
 ### Using pre-installed OpenCASCADE
 
-If you have `OCCT` library already installed via package manager you may use it to save huge amout of building time. By default `builtin` feature is enabled which means compiling OCCT from embedded sources. You can disable it via command line or using manifest:
+If you have the `OCCT` library already installed via a package manager, you can dynamically link to it which will significantly decrease build times. By default, the `builtin` feature is enabled which means compiling OCCT from source. You can disable it via the command line:
 
 `cargo build --no-default-features`
 
+or by specifying `default-features = false` in your `Cargo.toml`:
+
 ```
 [dependencies]
-opencascade = { version = "0.1", default-features = false, features = [] }
+opencascade = { version = "0.2", default-features = false }
 ```
 
-NOTE: If you have installed `OCCT` manually you may need specify path to it via `DEP_OCCT_ROOT` environment variable. Specified root directory usually expected contains `include` and `lib` directories.
+NOTE: If you have installed `OCCT` manually you may need specify the path to it via the `DEP_OCCT_ROOT` environment variable. The specified root directory usually contains `include` and `lib` directories.
 
 ## Run Examples
 

--- a/crates/opencascade-sys/Cargo.toml
+++ b/crates/opencascade-sys/Cargo.toml
@@ -13,4 +13,7 @@ cxx = "1"
 [build-dependencies]
 cmake = "0.1"
 cxx-build = "1"
-occt-sys = "0.2"
+occt-sys = { version = "0.3", optional = true }
+
+[features]
+builtin = ["occt-sys"]

--- a/crates/opencascade-sys/OCCT/CMakeLists.txt
+++ b/crates/opencascade-sys/OCCT/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
+project (OpenCASCADEPackageConfig)
+find_package (OpenCASCADE REQUIRED)
+
+file (WRITE ${CMAKE_BINARY_DIR}/occ_info.txt
+      "VERSION_MAJOR=${OpenCASCADE_MAJOR_VERSION}\n"
+      "VERSION_MINOR=${OpenCASCADE_MINOR_VERSION}\n"
+      "INCLUDE_DIR=${OpenCASCADE_INCLUDE_DIR}\n"
+      "LIBRARY_DIR=${OpenCASCADE_LIBRARY_DIR}\n"
+      "BUILD_SHARED_LIBS=${OpenCASCADE_BUILD_SHARED_LIBS}\n")
+
+install (FILES ${CMAKE_BINARY_DIR}/occ_info.txt TYPE DATA)

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -1,33 +1,47 @@
-use occt_sys::{occt_include_path, occt_lib_path};
+/// Minimum compatible version of OpenCASCADE library (major, minor)
+///
+/// Pre-installed OpenCASCADE library will be checked for compatibility using semver rules.
+const OCCT_VERSION: (u8, u8) = (7, 6);
+
+/// The list of used OpenCASCADE libraries which needs to be linked with.
+const OCCT_LIBS: &[&str] = &[
+    "TKMath",
+    "TKernel",
+    "TKFeat",
+    "TKGeomBase",
+    "TKG2d",
+    "TKG3d",
+    "TKTopAlgo",
+    "TKGeomAlgo",
+    "TKBRep",
+    "TKPrim",
+    "TKSTEP",
+    "TKSTEPAttr",
+    "TKSTEPBase",
+    "TKSTEP209",
+    "TKSTL",
+    "TKMesh",
+    "TKShHealing",
+    "TKFillet",
+    "TKBool",
+    "TKBO",
+    "TKOffset",
+    "TKXSBase",
+];
 
 fn main() {
     let target = std::env::var("TARGET").expect("No TARGET environment variable defined");
     let is_windows = target.to_lowercase().contains("windows");
     let is_windows_gnu = target.to_lowercase().contains("windows-gnu");
 
-    println!("cargo:rustc-link-search=native={}", occt_lib_path().to_str().unwrap());
-    println!("cargo:rustc-link-lib=static=TKMath");
-    println!("cargo:rustc-link-lib=static=TKernel");
-    println!("cargo:rustc-link-lib=static=TKFeat");
-    println!("cargo:rustc-link-lib=static=TKGeomBase");
-    println!("cargo:rustc-link-lib=static=TKG2d");
-    println!("cargo:rustc-link-lib=static=TKG3d");
-    println!("cargo:rustc-link-lib=static=TKTopAlgo");
-    println!("cargo:rustc-link-lib=static=TKGeomAlgo");
-    println!("cargo:rustc-link-lib=static=TKBRep");
-    println!("cargo:rustc-link-lib=static=TKPrim");
-    println!("cargo:rustc-link-lib=static=TKSTEP");
-    println!("cargo:rustc-link-lib=static=TKSTEPAttr");
-    println!("cargo:rustc-link-lib=static=TKSTEPBase");
-    println!("cargo:rustc-link-lib=static=TKSTEP209");
-    println!("cargo:rustc-link-lib=static=TKSTL");
-    println!("cargo:rustc-link-lib=static=TKMesh");
-    println!("cargo:rustc-link-lib=static=TKShHealing");
-    println!("cargo:rustc-link-lib=static=TKFillet");
-    println!("cargo:rustc-link-lib=static=TKBool");
-    println!("cargo:rustc-link-lib=static=TKBO");
-    println!("cargo:rustc-link-lib=static=TKOffset");
-    println!("cargo:rustc-link-lib=static=TKXSBase");
+    let occt_config = OcctConfig::detect();
+
+    println!("cargo:rustc-link-search=native={}", occt_config.library_dir.to_str().unwrap());
+
+    let lib_type = if occt_config.is_dynamic { "dylib" } else { "static" };
+    for lib in OCCT_LIBS {
+        println!("cargo:rustc-link-lib={lib_type}={lib}");
+    }
 
     if is_windows {
         println!("cargo:rustc-link-lib=dylib=user32");
@@ -43,7 +57,7 @@ fn main() {
         .cpp(true)
         .flag_if_supported("-std=c++11")
         .define("_USE_MATH_DEFINES", "TRUE")
-        .include(occt_include_path())
+        .include(occt_config.include_dir)
         .include("include")
         .compile("wrapper");
 
@@ -51,4 +65,70 @@ fn main() {
 
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=include/wrapper.hxx");
+}
+
+struct OcctConfig {
+    include_dir: std::path::PathBuf,
+    library_dir: std::path::PathBuf,
+    is_dynamic: bool,
+}
+
+impl OcctConfig {
+    /// Find OpenCASCADE library using cmake
+    fn detect() -> Self {
+        // Add path to builtin OCCT
+        #[cfg(feature = "builtin")]
+        {
+            std::env::set_var("DEP_OCCT_ROOT", occt_sys::occt_path().as_os_str());
+        }
+
+        let dst =
+            std::panic::catch_unwind(|| cmake::Config::new("OCCT").register_dep("occt").build());
+
+        #[cfg(feature = "builtin")]
+        let dst = dst.expect("Builtin OpenCASCADE library not found.");
+
+        #[cfg(not(feature = "builtin"))]
+        let dst = dst.expect("Pre-installed OpenCASCADE library not found. You can use `builtin` feature if you do not want to install OCCT libraries system-wide.");
+
+        let cfg = std::fs::read_to_string(dst.join("share").join("occ_info.txt"))
+            .expect("Something went wrong when detecting OpenCASCADE library.");
+
+        let mut version_major: Option<u8> = None;
+        let mut version_minor: Option<u8> = None;
+        let mut include_dir: Option<std::path::PathBuf> = None;
+        let mut library_dir: Option<std::path::PathBuf> = None;
+        let mut is_dynamic: bool = false;
+
+        for line in cfg.lines() {
+            if let Some((var, val)) = line.split_once('=') {
+                match var {
+                    "VERSION_MAJOR" => version_major = val.parse().ok(),
+                    "VERSION_MINOR" => version_minor = val.parse().ok(),
+                    "INCLUDE_DIR" => include_dir = val.parse().ok(),
+                    "LIBRARY_DIR" => library_dir = val.parse().ok(),
+                    "BUILD_SHARED_LIBS" => is_dynamic = val == "ON",
+                    _ => (),
+                }
+            }
+        }
+
+        if let (Some(version_major), Some(version_minor), Some(include_dir), Some(library_dir)) =
+            (version_major, version_minor, include_dir, library_dir)
+        {
+            if version_major != OCCT_VERSION.0 || version_minor < OCCT_VERSION.1 {
+                #[cfg(feature = "builtin")]
+                panic!("Builtin OpenCASCADE library found but version is not met (found {}.{} but {}.{} required). Please fix OCCT_VERSION in build script of `opencascade-sys` crate or submodule OCCT in `occt-sys` crate.",
+                       version_major, version_minor, OCCT_VERSION.0, OCCT_VERSION.1);
+
+                #[cfg(not(feature = "builtin"))]
+                panic!("Pre-installed OpenCASCADE library found but version is not met (found {}.{} but {}.{} required). Please provide required version or use `builtin` feature.",
+                       version_major, version_minor, OCCT_VERSION.0, OCCT_VERSION.1);
+            }
+
+            Self { include_dir, library_dir, is_dynamic }
+        } else {
+            panic!("OpenCASCADE library found but something wrong with config.");
+        }
+    }
 }

--- a/crates/opencascade/Cargo.toml
+++ b/crates/opencascade/Cargo.toml
@@ -12,3 +12,7 @@ cxx = "1"
 opencascade-sys = { version = "0.2", path = "../opencascade-sys" }
 glam = { version = "0.23", features = ["bytemuck"] }
 thiserror = "1"
+
+[features]
+default = ["builtin"]
+builtin = ["opencascade-sys/builtin"]

--- a/crates/viewer/Cargo.toml
+++ b/crates/viewer/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 [dependencies]
 bytemuck = { version = "1", features = ["derive"] }
 clap = { version = "4.3.19", features = ["derive"] }
-examples = { path = "../../examples" }
+examples = { path = "../../examples", default-features = false }
 glam = { version = "0.23", features = ["bytemuck"] }
-opencascade = { version = "0.2", path = "../opencascade" }
+opencascade = { version = "0.2", path = "../opencascade", default-features = false }
 simple-game = { git = "https://github.com/bschwind/simple-game.git" }
 smaa = "0.10"
 wgpu = "0.16"
@@ -16,3 +16,7 @@ winit = "0.28"
 
 [build-dependencies]
 naga = { version = "0.12", features = ["validate", "wgsl-in"] }
+
+[features]
+default = ["builtin"]
+builtin = ["opencascade/builtin", "examples/builtin"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-opencascade = { version = "0.2", path = "../crates/opencascade" }
+opencascade = { version = "0.2", path = "../crates/opencascade", default-features = false }
 glam = { version = "0.23", features = ["bytemuck"] }
+
+[features]
+default = ["builtin"]
+builtin = ["opencascade/builtin"]


### PR DESCRIPTION
This PR adds support installed version of **OpenCASCADE** library when it found and fits prerequisites. This drastically speeds up build. You can use `builtin` feature to prefer builtin version and skip detecting installed one.

Also added support for dynamic linking via using `dynamic` feature so this PR also superseeds #26.