### PR TITLE
RFC: viewer: draw XYZ axes

### DIFF
--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -83,6 +83,8 @@ impl GameApp for ViewerApp {
             line_builder.add_round_line_strip(&segments);
         }
 
+        draw_xyz_axes(&mut line_builder);
+
         let rendered_edges = line_builder.build(graphics_device.device());
 
         // Create SMAA target
@@ -214,6 +216,25 @@ impl GameApp for ViewerApp {
 
         self.fps_counter.tick();
     }
+}
+
+fn draw_xyz_axes(line_builder: &mut LineBuilder) {
+    let thickness = 1.0;
+    // TODO(Matej): this is a naive hack; how to determine proper extent?
+    let reach = 1000.0;
+
+    line_builder.add_round_line_strip(&[
+        LineVertex3::new(vec3(-reach, 0.0, 0.0), thickness, 0.0),
+        LineVertex3::new(vec3(reach, 0.0, 0.0), thickness, 2.0 * reach),
+    ]);
+    line_builder.add_round_line_strip(&[
+        LineVertex3::new(vec3(0.0, -reach, 0.0), thickness, 0.0),
+        LineVertex3::new(vec3(0.0, reach, 0.0), thickness, 2.0 * reach),
+    ]);
+    line_builder.add_round_line_strip(&[
+        LineVertex3::new(vec3(0.0, 0.0, -reach), thickness, 0.0),
+        LineVertex3::new(vec3(0.0, 0.0, reach), thickness, 2.0 * reach),
+    ]);
 }
 
 #[allow(unused)]


### PR DESCRIPTION
This is extremely naive implementation, but firing it just to get going. It seems to work, but I cannot rotate or zoom in the viewer (that's a privilege that only Mac users have at the moment).

Once finalized, fixes #62.

![Screenshot_20230723_181803](https://github.com/bschwind/opencascade-rs/assets/145366/f2c0e440-f26d-4dbb-9056-11e72a38e2f9)
