### PR TITLE
Fix the problem that the windows-gnu environment failed to find wrapper.hxx

### DIFF
--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -37,6 +37,9 @@ fn main() {
 
     if is_windows_gnu {
         build.define("OCC_CONVERT_SIGNALS", "TRUE");
+    }
+
+    if let "windows" = std::env::consts::OS {
         let current = std::env::current_dir().unwrap();
         build.include(current.parent().unwrap());
     } else {

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -42,8 +42,6 @@ fn main() {
     if let "windows" = std::env::consts::OS {
         let current = std::env::current_dir().unwrap();
         build.include(current.parent().unwrap());
-    } else {
-        build.include("include");
     }
 
     build
@@ -51,6 +49,7 @@ fn main() {
         .flag_if_supported("-std=c++11")
         .define("_USE_MATH_DEFINES", "TRUE")
         .include(occt_include_path())
+        .include("include")
         .compile("wrapper");
 
     println!("cargo:rustc-link-lib=static=wrapper");

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -37,6 +37,10 @@ fn main() {
 
     if is_windows_gnu {
         build.define("OCC_CONVERT_SIGNALS", "TRUE");
+        let current = std::env::current_dir().unwrap();
+        build.include(current.parent().unwrap());
+    } else {
+        build.include("include");
     }
 
     build
@@ -44,7 +48,6 @@ fn main() {
         .flag_if_supported("-std=c++11")
         .define("_USE_MATH_DEFINES", "TRUE")
         .include(occt_include_path())
-        .include("include")
         .compile("wrapper");
 
     println!("cargo:rustc-link-lib=static=wrapper");


### PR DESCRIPTION
environment:
```
rustc: x86_64-pc-windows-gnu stable 1.71.0
linker: mingw-13.1.0-release-posix-seh-ucrt-rt_v11-rev1
```
error:
```
fatal error: opencascade-sys/include/wrapper.hxx: No such file or directory
  cargo:warning=    1 | #include "opencascade-sys/include/wrapper.hxx"
  cargo:warning=      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=compilation terminated.
```
now, you have upgraded occt 7.7.1, it can be compiled normally in the windows environment, but still can not find ```wrapper.hxx```. #27 
i found out that i can manually set the environment variable:
```
CPLUS_INCLUDE_PATH = D:\workspace\opencascade-rs\crates
```
let it successfully find ```wrapper.hxx```(this problem may be because ```g++``` is a problem under different operating systems?)
then, I can let it find it directly in ```build.rs```, so as not to manually set the environment variable