### PR TITLE
Add command line argument to select example in viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ The [higher level examples](./crates/opencascade/examples) use more ergonomic Ru
 
 ## Viewer Application
 
-There is currently an experimental viewer application based on WGPU, which will probably become the "main" way people use this crate. It currently visualizes a hardcoded model produced in Rust code, but will expand to be capable of loading Rust model code compiled to WASM, allowing faster compile times and more interactive inspection of the sketches and models.
+There is currently an experimental viewer application based on WGPU, which will probably become the "main" way people use this crate. It currently visualizes one of the examples, but will expand to be capable of loading Rust model code compiled to WASM, allowing faster compile times and more interactive inspection of the sketches and models.
 
-You can run the current viewer app with
+To e.g. visualize the keycap example, you can run the current viewer app with
 
 ```
-$ cargo run --release --bin viewer
+$ cargo run --release --bin viewer -- keycap
 ```
 
 ## Code Formatting

--- a/crates/viewer/Cargo.toml
+++ b/crates/viewer/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bytemuck = { version = "1", features = ["derive"] }
+clap = { version = "4.3.19", features = ["derive"] }
 examples = { path = "../../examples" }
 glam = { version = "0.23", features = ["bytemuck"] }
 opencascade = { version = "0.1", path = "../opencascade" }


### PR DESCRIPTION
Supersedes #117 which was accidentally closed and can't be reopened due to a bug.