### PR TITLE
Add from_shapes for compound

### DIFF
--- a/crates/opencascade/src/primitives/compound.rs
+++ b/crates/opencascade/src/primitives/compound.rs
@@ -22,11 +22,4 @@ impl Compound {
 
         shape
     }
-
-    pub fn to_shape(self) -> Shape {
-        let inner_shape = ffi::cast_compound_to_shape(&self.inner);
-        let inner = ffi::TopoDS_Shape_to_owned(inner_shape);
-
-        Shape { inner }
-    }
 }

--- a/crates/opencascade/src/primitives/compound.rs
+++ b/crates/opencascade/src/primitives/compound.rs
@@ -22,4 +22,21 @@ impl Compound {
 
         shape
     }
+
+    pub fn from_shapes<T: AsRef<Shape>>(shapes: impl IntoIterator<Item = T>) -> Self {
+        let mut compound = ffi::TopoDS_Compound_ctor();
+        let builder = ffi::BRep_Builder_ctor();
+        let builder = ffi::BRep_Builder_upcast_to_topods_builder(&builder);
+        builder.MakeCompound(compound.pin_mut());
+        let mut compound_shape = ffi::TopoDS_Compound_as_shape(compound);
+
+        for shape in shapes.into_iter() {
+            builder.Add(compound_shape.pin_mut(), &shape.as_ref().inner);
+        }
+
+        let inner = ffi::TopoDS_cast_to_compound(&compound_shape);
+        let inner = ffi::TopoDS_Compound_to_owned(inner);
+
+        Self { inner }
+    }
 }

--- a/crates/opencascade/src/primitives/solid.rs
+++ b/crates/opencascade/src/primitives/solid.rs
@@ -17,13 +17,6 @@ impl AsRef<Solid> for Solid {
 }
 
 impl Solid {
-    pub fn to_shape(self) -> Shape {
-        let inner_shape = ffi::cast_solid_to_shape(&self.inner);
-        let inner = ffi::TopoDS_Shape_to_owned(inner_shape);
-
-        Shape { inner }
-    }
-
     // TODO(bschwind) - Do some cool stuff from this link:
     // https://neweopencascade.wordpress.com/2018/10/17/lets-talk-about-fillets/
     // Key takeaway: Use the `SectionEdges` function to retrieve edges that were

--- a/crates/opencascade/src/primitives/wire.rs
+++ b/crates/opencascade/src/primitives/wire.rs
@@ -1,6 +1,6 @@
 use crate::{
     angle::{Angle, ToAngle},
-    primitives::{make_dir, make_point, make_vec, Edge, Face, Shape},
+    primitives::{make_dir, make_point, make_vec, Edge, Face},
 };
 use cxx::UniquePtr;
 use glam::{dvec3, DVec3};
@@ -131,13 +131,6 @@ impl Wire {
         let inner = ffi::TopoDS_Face_to_owned(face);
 
         Face { inner }
-    }
-
-    pub fn to_shape(self) -> Shape {
-        let inner_shape = ffi::cast_wire_to_shape(&self.inner);
-        let inner = ffi::TopoDS_Shape_to_owned(inner_shape);
-
-        Shape { inner }
     }
 
     // Create a closure-based API


### PR DESCRIPTION
This PR adds a `from_shapes()` function to Compound. This is especially useful for displaying WIP models which do not consist of a single shape yet, e.g. when building a model from a bunch of faces.

It also cleans up the `to_shape()` functions which were accidentially reintroduced in #115.
