### PR TITLE
Make tolerance of meshing operations configurable

### DIFF
--- a/crates/opencascade/src/adhoc.rs
+++ b/crates/opencascade/src/adhoc.rs
@@ -2,43 +2,23 @@ use crate::primitives::Shape;
 use cxx::UniquePtr;
 use glam::DVec3;
 use opencascade_sys::ffi;
-use std::ops::{Deref, DerefMut};
 
-/// Wrapper for the [`Shape`] struct that provides an "ad-hoc" API. New code is encouraged
-/// to use more fine-grained API in the [`primitives`] module.
-pub struct AdHocShape(pub Shape);
-
-impl Deref for AdHocShape {
-    type Target = Shape;
-
-    fn deref(&self) -> &Shape {
-        &self.0
-    }
-}
-
-impl DerefMut for AdHocShape {
-    fn deref_mut(&mut self) -> &mut Shape {
-        &mut self.0
-    }
-}
+/// Collections of helper functions for the [`Shape`] struct that provides an "ad-hoc"
+/// API. New code is encouraged to use more fine-grained API in the [`primitives`] module.
+pub struct AdHocShape;
 
 impl AdHocShape {
-    /// Internal helper to create [Self] from the FFI shape type.
-    fn from_shape(shape: &ffi::TopoDS_Shape) -> Self {
-        Self(Shape::from_shape(shape))
-    }
-
     /// Make a box with a corner at (0,0,0) and with size (x,y,z)
-    pub fn make_box(x: f64, y: f64, z: f64) -> Self {
+    pub fn make_box(x: f64, y: f64, z: f64) -> Shape {
         let point = ffi::new_point(0.0, 0.0, 0.0);
         let mut my_box = ffi::BRepPrimAPI_MakeBox_ctor(&point, x, y, z);
 
-        Self::from_shape(my_box.pin_mut().Shape())
+        Shape::from_shape(my_box.pin_mut().Shape())
     }
 
     /// Make a box with one corner at p1, and the opposite corner
     /// at p2.
-    pub fn make_box_point_point(p1: DVec3, p2: DVec3) -> Self {
+    pub fn make_box_point_point(p1: DVec3, p2: DVec3) -> Shape {
         let min_corner = p1.min(p2);
         let max_corner = p1.max(p2);
 
@@ -46,24 +26,24 @@ impl AdHocShape {
         let diff = max_corner - min_corner;
         let mut my_box = ffi::BRepPrimAPI_MakeBox_ctor(&point, diff.x, diff.y, diff.z);
 
-        Self::from_shape(my_box.pin_mut().Shape())
+        Shape::from_shape(my_box.pin_mut().Shape())
     }
 
     /// Make a cylinder with its bottom at point p, with radius r and height h.
-    pub fn make_cylinder(p: DVec3, r: f64, h: f64) -> Self {
+    pub fn make_cylinder(p: DVec3, r: f64, h: f64) -> Shape {
         let point = ffi::new_point(p.x, p.y, p.z);
         let cylinder_axis = ffi::gp_DZ();
         let cylinder_coord_system = ffi::gp_Ax2_ctor(&point, cylinder_axis);
 
         let mut cylinder = ffi::BRepPrimAPI_MakeCylinder_ctor(&cylinder_coord_system, r, h);
 
-        Self::from_shape(cylinder.pin_mut().Shape())
+        Shape::from_shape(cylinder.pin_mut().Shape())
     }
 
     /// Purposefully underpowered for now, this simply takes a list of points,
     /// creates a face out of them, and then extrudes it by h in the positive Z
     /// direction.
-    pub fn extrude_polygon(points: &[DVec3], h: f64) -> Self {
+    pub fn extrude_polygon(points: &[DVec3], h: f64) -> Shape {
         assert!(points.len() >= 3);
 
         let mut make_wire = ffi::BRepBuilderAPI_MakeWire_ctor();
@@ -99,23 +79,23 @@ impl AdHocShape {
             true,
         );
 
-        Self::from_shape(extrusion.pin_mut().Shape())
+        Shape::from_shape(extrusion.pin_mut().Shape())
     }
 
     /// Drills a cylindrical hole starting at point p, pointing down the Z axis
     /// (this will later change to be an arbitrary axis).
-    pub fn drill_hole(&self, p: DVec3, dir: DVec3, radius: f64) -> Self {
+    pub fn drill_hole(shape: &Shape, p: DVec3, dir: DVec3, radius: f64) -> Shape {
         let point = ffi::new_point(p.x, p.y, p.z);
         let dir = ffi::gp_Dir_ctor(dir.x, dir.y, dir.z);
 
         let hole_axis = ffi::gp_Ax1_ctor(&point, &dir);
 
         let mut make_hole = ffi::BRepFeat_MakeCylindricalHole_ctor();
-        make_hole.pin_mut().Init(&self.inner, &hole_axis);
+        make_hole.pin_mut().Init(&shape.inner, &hole_axis);
 
         make_hole.pin_mut().Perform(radius);
         make_hole.pin_mut().Build();
 
-        Self::from_shape(make_hole.pin_mut().Shape())
+        Shape::from_shape(make_hole.pin_mut().Shape())
     }
 }

--- a/crates/opencascade/src/lib.rs
+++ b/crates/opencascade/src/lib.rs
@@ -8,10 +8,10 @@ pub mod workplane;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Failed to write STL file")]
+    #[error("failed to write STL file")]
     StlWriteFailed,
-    #[error("Failed to read STEP file")]
+    #[error("failed to read STEP file")]
     StepReadFailed,
-    #[error("Failed to write STEP file")]
+    #[error("failed to write STEP file")]
     StepWriteFailed,
 }

--- a/crates/opencascade/src/lib.rs
+++ b/crates/opencascade/src/lib.rs
@@ -14,4 +14,8 @@ pub enum Error {
     StepReadFailed,
     #[error("failed to write STEP file")]
     StepWriteFailed,
+    #[error("failed to triangulate Shape")]
+    TriangulationFailed,
+    #[error("encountered a face with no triangulation")]
+    UntriangulatedFace,
 }

--- a/crates/opencascade/src/mesh.rs
+++ b/crates/opencascade/src/mesh.rs
@@ -12,12 +12,12 @@ pub struct Mesh {
 }
 
 pub struct Mesher {
-    inner: UniquePtr<ffi::BRepMesh_IncrementalMesh>,
+    pub(crate) inner: UniquePtr<ffi::BRepMesh_IncrementalMesh>,
 }
 
 impl Mesher {
-    pub fn new(shape: &Shape) -> Self {
-        let inner = ffi::BRepMesh_IncrementalMesh_ctor(&shape.inner, 0.01);
+    pub fn new(shape: &Shape, triangulation_tolerance: f64) -> Self {
+        let inner = ffi::BRepMesh_IncrementalMesh_ctor(&shape.inner, triangulation_tolerance);
 
         if !inner.IsDone() {
             // TODO(bschwind) - Add proper Error type and return Result.

--- a/crates/opencascade/src/mesh.rs
+++ b/crates/opencascade/src/mesh.rs
@@ -22,9 +22,10 @@ impl Mesher {
     pub fn try_new(shape: &Shape, triangulation_tolerance: f64) -> Result<Self, Error> {
         let inner = ffi::BRepMesh_IncrementalMesh_ctor(&shape.inner, triangulation_tolerance);
 
-        match inner.IsDone() {
-            true => Ok(Self { inner }),
-            false => Err(Error::TriangulationFailed),
+        if inner.IsDone() {
+            Ok(Self { inner })
+        } else {
+            Err(Error::TriangulationFailed)
         }
     }
 

--- a/crates/opencascade/src/mesh.rs
+++ b/crates/opencascade/src/mesh.rs
@@ -35,8 +35,7 @@ impl Mesher {
         let mut normals = vec![];
         let mut indices = vec![];
 
-        let triangulated_shape = ffi::TopoDS_Shape_to_owned(self.inner.pin_mut().Shape());
-        let triangulated_shape = Shape { inner: triangulated_shape };
+        let triangulated_shape = Shape::from_shape(self.inner.pin_mut().Shape());
 
         for face in triangulated_shape.faces() {
             let mut location = ffi::TopLoc_Location_ctor();

--- a/crates/opencascade/src/primitives.rs
+++ b/crates/opencascade/src/primitives.rs
@@ -117,11 +117,11 @@ impl Iterator for EdgeIterator {
     fn next(&mut self) -> Option<Self::Item> {
         if self.explorer.More() {
             let edge = ffi::TopoDS_cast_to_edge(self.explorer.Current());
-            let inner = ffi::TopoDS_Edge_to_owned(edge);
+            let edge = Edge::from_edge(edge);
 
             self.explorer.pin_mut().Next();
 
-            Some(Edge { inner })
+            Some(edge)
         } else {
             None
         }
@@ -181,11 +181,11 @@ impl Iterator for FaceIterator {
     fn next(&mut self) -> Option<Self::Item> {
         if self.explorer.More() {
             let face = ffi::TopoDS_cast_to_face(self.explorer.Current());
-            let inner = ffi::TopoDS_Face_to_owned(face);
+            let face = Face::from_face(face);
 
             self.explorer.pin_mut().Next();
 
-            Some(Face { inner })
+            Some(face)
         } else {
             None
         }

--- a/crates/opencascade/src/primitives/boolean_shape.rs
+++ b/crates/opencascade/src/primitives/boolean_shape.rs
@@ -27,11 +27,13 @@ impl BooleanShape {
         self.new_edges.iter()
     }
 
-    pub fn fillet_new_edges(&mut self, radius: f64) {
-        self.shape.fillet_edges(radius, &self.new_edges);
+    #[must_use]
+    pub fn fillet_new_edges(&self, radius: f64) -> Shape {
+        self.shape.fillet_edges(radius, &self.new_edges)
     }
 
-    pub fn chamfer_new_edges(&mut self, distance: f64) {
-        self.shape.chamfer_edges(distance, &self.new_edges);
+    #[must_use]
+    pub fn chamfer_new_edges(&self, distance: f64) -> Shape {
+        self.shape.chamfer_edges(distance, &self.new_edges)
     }
 }

--- a/crates/opencascade/src/primitives/edge.rs
+++ b/crates/opencascade/src/primitives/edge.rs
@@ -14,11 +14,14 @@ impl AsRef<Edge> for Edge {
 }
 
 impl Edge {
-    fn from_make_edge(mut make_edge: UniquePtr<ffi::BRepBuilderAPI_MakeEdge>) -> Self {
-        let edge = make_edge.pin_mut().Edge();
+    pub(crate) fn from_edge(edge: &ffi::TopoDS_Edge) -> Self {
         let inner = ffi::TopoDS_Edge_to_owned(edge);
 
         Self { inner }
+    }
+
+    fn from_make_edge(mut make_edge: UniquePtr<ffi::BRepBuilderAPI_MakeEdge>) -> Self {
+        Self::from_edge(make_edge.pin_mut().Edge())
     }
 
     pub fn segment(p1: DVec3, p2: DVec3) -> Self {

--- a/crates/opencascade/src/primitives/face.rs
+++ b/crates/opencascade/src/primitives/face.rs
@@ -28,7 +28,6 @@ impl Face {
         Self::from_face(make_face.Face())
     }
 
-    #[must_use]
     pub fn from_wire(wire: &Wire) -> Self {
         let only_plane = false;
         let make_face = ffi::BRepBuilderAPI_MakeFace_wire(&wire.inner, only_plane);
@@ -36,7 +35,6 @@ impl Face {
         Self::from_make_face(make_face)
     }
 
-    #[must_use]
     pub fn from_surface(surface: &Surface) -> Self {
         const EDGE_TOLERANCE: f64 = 0.0001;
 

--- a/crates/opencascade/src/primitives/face.rs
+++ b/crates/opencascade/src/primitives/face.rs
@@ -18,13 +18,17 @@ impl AsRef<Face> for Face {
 }
 
 impl Face {
-    fn from_make_face(make_face: UniquePtr<ffi::BRepBuilderAPI_MakeFace>) -> Self {
-        let face = make_face.Face();
+    pub(crate) fn from_face(face: &ffi::TopoDS_Face) -> Self {
         let inner = ffi::TopoDS_Face_to_owned(face);
 
         Self { inner }
     }
 
+    fn from_make_face(make_face: UniquePtr<ffi::BRepBuilderAPI_MakeFace>) -> Self {
+        Self::from_face(make_face.Face())
+    }
+
+    #[must_use]
     pub fn from_wire(wire: &Wire) -> Self {
         let only_plane = false;
         let make_face = ffi::BRepBuilderAPI_MakeFace_wire(&wire.inner, only_plane);
@@ -32,6 +36,7 @@ impl Face {
         Self::from_make_face(make_face)
     }
 
+    #[must_use]
     pub fn from_surface(surface: &Surface) -> Self {
         const EDGE_TOLERANCE: f64 = 0.0001;
 
@@ -40,6 +45,7 @@ impl Face {
         Self::from_make_face(make_face)
     }
 
+    #[must_use]
     pub fn extrude(&self, dir: DVec3) -> Solid {
         let prism_vec = make_vec(dir);
 
@@ -51,11 +57,11 @@ impl Face {
             ffi::BRepPrimAPI_MakePrism_ctor(inner_shape, &prism_vec, copy, canonize);
         let extruded_shape = make_solid.pin_mut().Shape();
         let solid = ffi::TopoDS_cast_to_solid(extruded_shape);
-        let inner = ffi::TopoDS_Solid_to_owned(solid);
 
-        Solid { inner }
+        Solid::from_solid(solid)
     }
 
+    #[must_use]
     pub fn extrude_to_face(&self, shape_with_face: &Shape, face: &Face) -> Shape {
         let profile_base = &self.inner;
         let sketch_base = ffi::TopoDS_Face_ctor();
@@ -75,12 +81,10 @@ impl Face {
         let until_face = ffi::cast_face_to_shape(&face.inner);
         make_prism.pin_mut().perform_until_face(until_face);
 
-        let extruded_shape = make_prism.pin_mut().Shape();
-        let inner = ffi::TopoDS_Shape_to_owned(extruded_shape);
-
-        Shape { inner }
+        Shape::from_shape(make_prism.pin_mut().Shape())
     }
 
+    #[must_use]
     pub fn subtractive_extrude(&self, shape_with_face: &Shape, height: f64) -> Shape {
         let profile_base = &self.inner;
         let sketch_base = ffi::TopoDS_Face_ctor();
@@ -99,12 +103,10 @@ impl Face {
 
         make_prism.pin_mut().perform_with_height(height);
 
-        let extruded_shape = make_prism.pin_mut().Shape();
-        let inner = ffi::TopoDS_Shape_to_owned(extruded_shape);
-
-        Shape { inner }
+        Shape::from_shape(make_prism.pin_mut().Shape())
     }
 
+    #[must_use]
     pub fn revolve(&self, origin: DVec3, axis: DVec3, angle: Option<Angle>) -> Solid {
         let revol_vec = make_axis_1(origin, axis);
 
@@ -115,13 +117,13 @@ impl Face {
         let mut make_solid = ffi::BRepPrimAPI_MakeRevol_ctor(inner_shape, &revol_vec, angle, copy);
         let revolved_shape = make_solid.pin_mut().Shape();
         let solid = ffi::TopoDS_cast_to_solid(revolved_shape);
-        let inner = ffi::TopoDS_Solid_to_owned(solid);
 
-        Solid { inner }
+        Solid::from_solid(solid)
     }
 
     /// Fillets the face edges by a given radius at each vertex
-    pub fn fillet(&mut self, radius: f64) {
+    #[must_use]
+    pub fn fillet(&self, radius: f64) -> Self {
         let mut make_fillet = ffi::BRepFilletAPI_MakeFillet2d_ctor(&self.inner);
 
         let face_shape = ffi::cast_face_to_shape(&self.inner);
@@ -140,11 +142,12 @@ impl Face {
         let result_shape = make_fillet.pin_mut().Shape();
         let result_face = ffi::TopoDS_cast_to_face(result_shape);
 
-        self.inner = ffi::TopoDS_Face_to_owned(result_face);
+        Self::from_face(result_face)
     }
 
     /// Chamfer the wire edges at each vertex by a given distance
-    pub fn chamfer(&mut self, distance_1: f64) {
+    #[must_use]
+    pub fn chamfer(&self, distance_1: f64) -> Self {
         // TODO - Support asymmetric chamfers.
         let distance_2 = distance_1;
 
@@ -181,7 +184,7 @@ impl Face {
         let filleted_shape = make_fillet.pin_mut().Shape();
         let result_face = ffi::TopoDS_cast_to_face(filleted_shape);
 
-        self.inner = ffi::TopoDS_Face_to_owned(result_face);
+        Self::from_face(result_face)
     }
 
     pub fn edges(&self) -> EdgeIterator {
@@ -253,20 +256,12 @@ impl Face {
         let fuse_shape = fuse_operation.pin_mut().Shape();
 
         let compound = ffi::TopoDS_cast_to_compound(fuse_shape);
-        let inner = ffi::TopoDS_Compound_to_owned(compound);
 
-        CompoundFace { inner }
+        CompoundFace::from_compound(compound)
     }
 
     pub fn orientation(&self) -> FaceOrientation {
         FaceOrientation::from(self.inner.Orientation())
-    }
-
-    pub fn from_shape(shape: &Shape) -> Self {
-        let face = ffi::TopoDS_cast_to_face(&shape.inner);
-        let inner = ffi::TopoDS_Face_to_owned(face);
-
-        Self { inner }
     }
 }
 
@@ -281,19 +276,23 @@ impl AsRef<CompoundFace> for CompoundFace {
 }
 
 impl CompoundFace {
-    pub fn clean(&mut self) -> Self {
-        let inner = ffi::cast_compound_to_shape(&self.inner);
-        let inner = ffi::TopoDS_Shape_to_owned(inner);
-        let mut shape = Shape { inner };
-
-        shape.clean();
-
-        let inner = ffi::TopoDS_cast_to_compound(&shape.inner);
-        let inner = ffi::TopoDS_Compound_to_owned(inner);
+    pub(crate) fn from_compound(compound: &ffi::TopoDS_Compound) -> Self {
+        let inner = ffi::TopoDS_Compound_to_owned(compound);
 
         Self { inner }
     }
 
+    #[must_use]
+    pub fn clean(&self) -> Self {
+        let shape = ffi::cast_compound_to_shape(&self.inner);
+        let shape = Shape::from_shape(shape).clean();
+
+        let compound = ffi::TopoDS_cast_to_compound(&shape.inner);
+
+        Self::from_compound(compound)
+    }
+
+    #[must_use]
     pub fn extrude(&self, dir: DVec3) -> Shape {
         let prism_vec = make_vec(dir);
 
@@ -305,11 +304,11 @@ impl CompoundFace {
         let mut make_solid =
             ffi::BRepPrimAPI_MakePrism_ctor(inner_shape, &prism_vec, copy, canonize);
         let extruded_shape = make_solid.pin_mut().Shape();
-        let inner = ffi::TopoDS_Shape_to_owned(extruded_shape);
 
-        Shape { inner }
+        Shape::from_shape(extruded_shape)
     }
 
+    #[must_use]
     pub fn revolve(&self, origin: DVec3, axis: DVec3, angle: Option<Angle>) -> Shape {
         let revol_axis = make_axis_1(origin, axis);
 
@@ -320,22 +319,18 @@ impl CompoundFace {
 
         let mut make_solid = ffi::BRepPrimAPI_MakeRevol_ctor(inner_shape, &revol_axis, angle, copy);
         let revolved_shape = make_solid.pin_mut().Shape();
-        let inner = ffi::TopoDS_Shape_to_owned(revolved_shape);
 
-        Shape { inner }
+        Shape::from_shape(revolved_shape)
     }
 
     pub fn set_global_translation(&mut self, translation: DVec3) {
-        let inner = ffi::cast_compound_to_shape(&self.inner);
-        let inner = ffi::TopoDS_Shape_to_owned(inner);
-        let mut shape = Shape { inner };
+        let shape = ffi::cast_compound_to_shape(&self.inner);
+        let mut shape = Shape::from_shape(shape);
 
         shape.set_global_translation(translation);
 
         let compound = ffi::TopoDS_cast_to_compound(&shape.inner);
-        let compound = ffi::TopoDS_Compound_to_owned(compound);
-
-        self.inner = compound;
+        *self = Self::from_compound(compound);
     }
 }
 

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -236,7 +236,7 @@ impl Shape {
         triangulation_tolerance: f64,
     ) -> Result<(), Error> {
         let mut stl_writer = ffi::StlAPI_Writer_ctor();
-        let mesher = Mesher::new(self, triangulation_tolerance);
+        let mesher = Mesher::try_new(self, triangulation_tolerance)?;
         let success = ffi::write_stl(
             stl_writer.pin_mut(),
             mesher.inner.Shape(),
@@ -270,24 +270,22 @@ impl Shape {
         self.inner.pin_mut().set_global_translation(&location, false);
     }
 
-    pub fn mesh(&self) -> Mesh {
+    pub fn mesh(&self) -> Result<Mesh, Error> {
         self.mesh_with_tolerance(0.01)
     }
 
-    pub fn mesh_with_tolerance(&self, triangulation_tolerance: f64) -> Mesh {
-        let mesher = Mesher::new(self, triangulation_tolerance);
+    pub fn mesh_with_tolerance(&self, triangulation_tolerance: f64) -> Result<Mesh, Error> {
+        let mesher = Mesher::try_new(self, triangulation_tolerance)?;
         mesher.mesh()
     }
 
     pub fn edges(&self) -> EdgeIterator {
         let explorer = ffi::TopExp_Explorer_ctor(&self.inner, ffi::TopAbs_ShapeEnum::TopAbs_EDGE);
-
         EdgeIterator { explorer }
     }
 
     pub fn faces(&self) -> FaceIterator {
         let explorer = ffi::TopExp_Explorer_ctor(&self.inner, ffi::TopAbs_ShapeEnum::TopAbs_FACE);
-
         FaceIterator { explorer }
     }
 

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -227,11 +227,19 @@ impl Shape {
     }
 
     pub fn write_stl<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+        self.write_stl_with_tolerance(path, 0.001)
+    }
+
+    pub fn write_stl_with_tolerance<P: AsRef<Path>>(
+        &self,
+        path: P,
+        triangulation_tolerance: f64,
+    ) -> Result<(), Error> {
         let mut stl_writer = ffi::StlAPI_Writer_ctor();
-        let triangulation = ffi::BRepMesh_IncrementalMesh_ctor(&self.inner, 0.001);
+        let mesher = Mesher::new(self, triangulation_tolerance);
         let success = ffi::write_stl(
             stl_writer.pin_mut(),
-            triangulation.Shape(),
+            mesher.inner.Shape(),
             path.as_ref().to_string_lossy().to_string(),
         );
 
@@ -263,7 +271,11 @@ impl Shape {
     }
 
     pub fn mesh(&self) -> Mesh {
-        let mesher = Mesher::new(self);
+        self.mesh_with_tolerance(0.01)
+    }
+
+    pub fn mesh_with_tolerance(&self, triangulation_tolerance: f64) -> Mesh {
+        let mesher = Mesher::new(self, triangulation_tolerance);
         mesher.mesh()
     }
 

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -1,5 +1,4 @@
 use crate::{
-    adhoc::AdHocShape,
     mesh::{Mesh, Mesher},
     primitives::{
         make_dir, make_point, make_vec, BooleanShape, Compound, Edge, EdgeIterator, Face,
@@ -73,12 +72,6 @@ impl From<Compound> for Shape {
 impl From<BooleanShape> for Shape {
     fn from(boolean_shape: BooleanShape) -> Self {
         boolean_shape.shape
-    }
-}
-
-impl From<AdHocShape> for Shape {
-    fn from(adhoc_shape: AdHocShape) -> Self {
-        adhoc_shape.0
     }
 }
 

--- a/crates/opencascade/src/primitives/solid.rs
+++ b/crates/opencascade/src/primitives/solid.rs
@@ -37,7 +37,6 @@ impl Solid {
         Compound::from_compound(compound)
     }
 
-    #[must_use]
     pub fn loft<T: AsRef<Wire>>(wires: impl IntoIterator<Item = T>) -> Self {
         let is_solid = true;
         let mut make_loft = ffi::BRepOffsetAPI_ThruSections_ctor(is_solid);

--- a/crates/opencascade/src/primitives/solid.rs
+++ b/crates/opencascade/src/primitives/solid.rs
@@ -1,10 +1,6 @@
-use crate::{
-    primitives::{BooleanShape, Compound, Edge, Shape, Wire},
-    Error,
-};
+use crate::primitives::{BooleanShape, Compound, Edge, Shape, Wire};
 use cxx::UniquePtr;
 use opencascade_sys::ffi;
-use std::path::Path;
 
 pub struct Solid {
     pub(crate) inner: UniquePtr<ffi::TopoDS_Solid>,
@@ -51,24 +47,6 @@ impl Solid {
         let inner = ffi::TopoDS_Solid_to_owned(solid);
 
         Self { inner }
-    }
-
-    pub fn write_stl<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
-        let inner_shape = ffi::cast_solid_to_shape(&self.inner);
-
-        let mut stl_writer = ffi::StlAPI_Writer_ctor();
-        let triangulation = ffi::BRepMesh_IncrementalMesh_ctor(inner_shape, 0.001);
-        let success = ffi::write_stl(
-            stl_writer.pin_mut(),
-            triangulation.Shape(),
-            path.as_ref().to_string_lossy().to_string(),
-        );
-
-        if success {
-            Ok(())
-        } else {
-            Err(Error::StlWriteFailed)
-        }
     }
 
     pub fn subtract(&self, other: &Solid) -> BooleanShape {

--- a/crates/opencascade/src/primitives/wire.rs
+++ b/crates/opencascade/src/primitives/wire.rs
@@ -1,6 +1,6 @@
 use crate::{
     angle::{Angle, ToAngle},
-    primitives::{make_dir, make_point, make_vec, Edge, Face},
+    primitives::{make_dir, make_point, make_vec, Edge, Face, Shape},
 };
 use cxx::UniquePtr;
 use glam::{dvec3, DVec3};
@@ -17,11 +17,14 @@ impl AsRef<Wire> for Wire {
 }
 
 impl Wire {
-    fn from_make_wire(mut make_wire: UniquePtr<ffi::BRepBuilderAPI_MakeWire>) -> Self {
-        let wire = make_wire.pin_mut().Wire();
+    pub(crate) fn from_wire(wire: &ffi::TopoDS_Wire) -> Self {
         let inner = ffi::TopoDS_Wire_to_owned(wire);
 
         Self { inner }
+    }
+
+    fn from_make_wire(mut make_wire: UniquePtr<ffi::BRepBuilderAPI_MakeWire>) -> Self {
+        Self::from_wire(make_wire.pin_mut().Wire())
     }
 
     pub fn from_edges<'a>(edges: impl IntoIterator<Item = &'a Edge>) -> Self {
@@ -44,6 +47,7 @@ impl Wire {
         Self::from_make_wire(make_wire)
     }
 
+    #[must_use]
     pub fn mirror_along_axis(&self, axis_origin: DVec3, axis_dir: DVec3) -> Self {
         let axis_dir = make_dir(axis_dir);
         let axis = ffi::gp_Ax1_ctor(&make_point(axis_origin), &axis_dir);
@@ -58,9 +62,8 @@ impl Wire {
 
         let mirrored_shape = brep_transform.pin_mut().Shape();
         let mirrored_wire = ffi::TopoDS_cast_to_wire(mirrored_shape);
-        let inner = ffi::TopoDS_Wire_to_owned(mirrored_wire);
 
-        Self { inner }
+        Self::from_wire(mirrored_wire)
     }
 
     pub fn rect(width: f64, height: f64) -> Self {
@@ -80,30 +83,31 @@ impl Wire {
         Self::from_edges([&top, &right, &bottom, &left])
     }
 
-    pub fn fillet(&mut self, radius: f64) {
+    #[must_use]
+    pub fn fillet(&mut self, radius: f64) -> Wire {
         // Create a face from this wire
-        let mut face = Face::from_wire(self);
-        face.fillet(radius);
-        let wire = ffi::outer_wire(&face.inner);
+        let face = Face::from_wire(self).fillet(radius);
+        let inner = ffi::outer_wire(&face.inner);
 
-        self.inner = wire;
+        Self { inner }
     }
 
     /// Chamfer the wire edges at each vertex by a given distance.
-    pub fn chamfer(&mut self, distance_1: f64) {
-        let mut face = Face::from_wire(self);
-        face.chamfer(distance_1);
+    #[must_use]
+    pub fn chamfer(&mut self, distance_1: f64) -> Wire {
+        let face = Face::from_wire(self).chamfer(distance_1);
+        let inner = ffi::outer_wire(&face.inner);
 
-        let wire = ffi::outer_wire(&face.inner);
-
-        self.inner = wire;
+        Self { inner }
     }
 
-    pub fn translate(&mut self, offset: DVec3) {
-        self.transform(offset, dvec3(1.0, 0.0, 0.0), 0.degrees());
+    #[must_use]
+    pub fn translate(&self, offset: DVec3) -> Self {
+        self.transform(offset, dvec3(1.0, 0.0, 0.0), 0.degrees())
     }
 
-    pub fn transform(&mut self, translation: DVec3, rotation_axis: DVec3, angle: Angle) {
+    #[must_use]
+    pub fn transform(&self, translation: DVec3, rotation_axis: DVec3, angle: Angle) -> Self {
         let mut transform = ffi::new_transform();
         let rotation_axis_vec =
             ffi::gp_Ax1_ctor(&make_point(DVec3::ZERO), &make_dir(rotation_axis));
@@ -114,23 +118,21 @@ impl Wire {
         let location = ffi::TopLoc_Location_from_transform(&transform);
 
         let wire_shape = ffi::cast_wire_to_shape(&self.inner);
-        let mut wire_shape = ffi::TopoDS_Shape_to_owned(wire_shape);
+        let mut wire_shape = Shape::from_shape(wire_shape).inner;
 
         let raise_exception = false;
         wire_shape.pin_mut().translate(&location, raise_exception);
 
         let translated_wire = ffi::TopoDS_cast_to_wire(&wire_shape);
-        self.inner = ffi::TopoDS_Wire_to_owned(translated_wire);
+
+        Self::from_wire(translated_wire)
     }
 
     pub fn to_face(self) -> Face {
         let only_plane = false;
         let make_face = ffi::BRepBuilderAPI_MakeFace_wire(&self.inner, only_plane);
 
-        let face = make_face.Face();
-        let inner = ffi::TopoDS_Face_to_owned(face);
-
-        Face { inner }
+        Face::from_face(make_face.Face())
     }
 
     // Create a closure-based API

--- a/crates/opencascade/src/primitives/wire.rs
+++ b/crates/opencascade/src/primitives/wire.rs
@@ -84,7 +84,7 @@ impl Wire {
     }
 
     #[must_use]
-    pub fn fillet(&mut self, radius: f64) -> Wire {
+    pub fn fillet(&self, radius: f64) -> Wire {
         // Create a face from this wire
         let face = Face::from_wire(self).fillet(radius);
         let inner = ffi::outer_wire(&face.inner);
@@ -94,7 +94,7 @@ impl Wire {
 
     /// Chamfer the wire edges at each vertex by a given distance.
     #[must_use]
-    pub fn chamfer(&mut self, distance_1: f64) -> Wire {
+    pub fn chamfer(&self, distance_1: f64) -> Wire {
         let face = Face::from_wire(self).chamfer(distance_1);
         let inner = ffi::outer_wire(&face.inner);
 

--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -76,7 +76,7 @@ impl GameApp for ViewerApp {
         let example = Example::parse();
         let shape = example.shape();
 
-        let mesh = shape.mesh().unwrap();
+        let mesh = shape.mesh().expect("example shape should yield a valid triangulation");
         let cad_mesh = CadMesh::from_mesh(&mesh, graphics_device.device());
 
         // Pre-render the model edges.

--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -76,7 +76,7 @@ impl GameApp for ViewerApp {
         let example = Example::parse();
         let shape = example.shape();
 
-        let mesh = shape.mesh();
+        let mesh = shape.mesh().unwrap();
         let cad_mesh = CadMesh::from_mesh(&mesh, graphics_device.device());
 
         // Pre-render the model edges.

--- a/examples/src/box_shape.rs
+++ b/examples/src/box_shape.rs
@@ -5,6 +5,6 @@ pub fn shape() -> Shape {
     let another_box = AdHocShape::make_box(1.0, 1.0, 0.8);
 
     my_box.subtract(&another_box);
-    my_box.chamfer_edges(0.07);
+    my_box.chamfer(0.07);
     my_box.into()
 }

--- a/examples/src/box_shape.rs
+++ b/examples/src/box_shape.rs
@@ -1,10 +1,8 @@
 use opencascade::{adhoc::AdHocShape, primitives::Shape};
 
 pub fn shape() -> Shape {
-    let mut my_box = AdHocShape::make_box(10.0, 10.0, 1.0);
+    let my_box = AdHocShape::make_box(10.0, 10.0, 1.0);
     let another_box = AdHocShape::make_box(1.0, 1.0, 0.8);
 
-    my_box.subtract(&another_box);
-    my_box.chamfer(0.07);
-    my_box.into()
+    my_box.subtract(&another_box).chamfer(0.07)
 }

--- a/examples/src/chamfer.rs
+++ b/examples/src/chamfer.rs
@@ -6,12 +6,8 @@ use opencascade::{
 
 pub fn shape() -> Shape {
     // A tapering chamfer from bottom to top 2->1
-    let mut base = Workplane::xy().rect(10.0, 10.0);
-    base.chamfer(2.0);
-
-    let mut top = Workplane::xy().rect(10.0, 10.0);
-    top.translate(dvec3(0.0, 0.0, 10.0));
-    top.chamfer(1.0);
+    let base = Workplane::xy().rect(10.0, 10.0).chamfer(2.0);
+    let top = Workplane::xy().rect(10.0, 10.0).translate(dvec3(0.0, 0.0, 10.0)).chamfer(1.0);
 
     let chamfered_box = Solid::loft([&base, &top]);
 
@@ -20,8 +16,7 @@ pub fn shape() -> Shape {
     let handle_face = Face::from_wire(&handle);
 
     let handle_body = handle_face.extrude(dvec3(0.0, 0.0, -10.1));
-    let mut chamfered_shape = chamfered_box.union(&handle_body);
-    chamfered_shape.chamfer_new_edges(0.5);
+    let chamfered_shape = chamfered_box.union(&handle_body).chamfer_new_edges(0.5);
 
     // Chamfer the top of the protrusion
     let top_edges = chamfered_shape
@@ -29,10 +24,8 @@ pub fn shape() -> Shape {
         .farthest(Direction::NegZ) // Get the face whose center of mass is the farthest in the negative Z direction
         .edges(); // Get all the edges of this face
 
-    chamfered_shape.chamfer_edges(1.0, top_edges);
+    chamfered_shape.chamfer_edges(1.0, top_edges)
 
     // Can also just chamfer the whole shape with:
-    // chamfered_shape.chamfer(0.5);
-
-    chamfered_shape.into()
+    // chamfered_shape.chamfer(0.5)
 }

--- a/examples/src/high_level_bottle.rs
+++ b/examples/src/high_level_bottle.rs
@@ -34,7 +34,7 @@ pub fn shape() -> Shape {
     let neck_radius = thickness / 4.0;
     let neck_height = height / 10.0;
 
-    let mut neck = AdHocShape::make_cylinder(dvec3(0.0, 0.0, height), neck_radius, neck_height);
+    let neck = AdHocShape::make_cylinder(dvec3(0.0, 0.0, height), neck_radius, neck_height);
     neck.union(&body);
 
     let bottle = neck.0;

--- a/examples/src/high_level_bottle.rs
+++ b/examples/src/high_level_bottle.rs
@@ -1,7 +1,7 @@
 use glam::dvec3;
 use opencascade::{
     adhoc::AdHocShape,
-    primitives::{Direction::PosZ, Edge, Face, Shape, Wire},
+    primitives::{Direction::PosZ, Edge, Face, IntoShape, Shape, Wire},
 };
 
 pub fn shape() -> Shape {
@@ -26,18 +26,15 @@ pub fn shape() -> Shape {
     let wire_profile = Wire::from_wires([&wire, &mirrored_wire]);
     let face_profile = Face::from_wire(&wire_profile);
 
-    let body = face_profile.extrude(dvec3(0.0, 0.0, height));
-    let mut body: Shape = body.into();
-    body.fillet_edges(thickness / 12.0, body.edges());
+    let body = face_profile.extrude(dvec3(0.0, 0.0, height)).into_shape().fillet(thickness / 12.0);
 
     // Create the neck and join it with the body
     let neck_radius = thickness / 4.0;
     let neck_height = height / 10.0;
 
     let neck = AdHocShape::make_cylinder(dvec3(0.0, 0.0, height), neck_radius, neck_height);
-    neck.union(&body);
+    let bottle = neck.union(&body);
 
-    let bottle = neck.0;
     let top_face = bottle.faces().farthest(PosZ);
     bottle.hollow(-thickness / 50.0, [top_face])
 }

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -73,7 +73,7 @@ impl SupportPost {
         let top_z = TOP_PLATE_BOTTOM_Z;
 
         let pos = DVec3::from((self.pos, CASE_FLOOR_Z));
-        let mut cylinder = AdHocShape::make_cylinder(pos, SUPPORT_POST_RADIUS, top_z - bottom_z);
+        let cylinder = AdHocShape::make_cylinder(pos, SUPPORT_POST_RADIUS, top_z - bottom_z);
         let m2_drill_hole =
             AdHocShape::make_cylinder(pos, SUPPORT_POST_DRILL_RADIUS, top_z - bottom_z);
 
@@ -215,7 +215,7 @@ fn pcb_bottom_shelf() -> AdHocShape {
     let corner_1 = DVec3::new(PCB_LEFT, PCB_BOTTOM + PCB_SHELF_THICKNESS_BOTTOM, CASE_FLOOR_Z);
     let corner_2 = DVec3::new(PCB_RIGHT, PCB_BOTTOM, CASE_FLOOR_Z + PCB_SHELF_HEIGHT);
 
-    let mut bottom_shelf = AdHocShape::make_box_point_point(corner_1, corner_2);
+    let bottom_shelf = AdHocShape::make_box_point_point(corner_1, corner_2);
 
     // Cut out gaps for the space bar stabilizer.
 
@@ -246,7 +246,7 @@ fn usb_connector_cutout() -> AdHocShape {
 
     let mut shape = AdHocShape::make_box_point_point(corner_1, corner_2);
 
-    shape.fillet_edges(2.0);
+    shape.fillet(2.0);
     shape
 }
 
@@ -272,7 +272,7 @@ pub fn shape() -> Shape {
     let usb_cutout = usb_connector_cutout();
 
     outer_box.subtract(&inner_box);
-    outer_box.fillet_edges(1.3);
+    outer_box.fillet(1.3);
 
     outer_box.union(&top_shelf);
     outer_box.union(&bottom_shelf);

--- a/examples/src/rounded_chamfer.rs
+++ b/examples/src/rounded_chamfer.rs
@@ -8,13 +8,14 @@ use opencascade::{
 // the top edges, resulting in a nice, rounded chamfer.
 
 pub fn shape() -> Shape {
-    let mut base = Workplane::xy().rect(16.0, 10.0);
-    base.fillet(1.0);
-    let shape = base.to_face().extrude(dvec3(0.0, 0.0, 3.0));
-    let mut shape = shape.into_shape();
+    let shape = Workplane::xy()
+        .rect(16.0, 10.0)
+        .fillet(1.0)
+        .to_face()
+        .extrude(dvec3(0.0, 0.0, 3.0))
+        .into_shape();
 
     let top_edges = shape.faces().farthest(Direction::PosZ).edges();
-    shape.chamfer_edges(0.7, top_edges);
 
-    shape
+    shape.chamfer_edges(0.7, top_edges)
 }


### PR DESCRIPTION
This PR makes the triangulation tolerance used in the meshing operations configurable. It also introduces error handling for the meshing operations as well as doing some deduplication of the AdhocShape/Solid methods with the shape ones.
