### PR TITLE
update glam dependency to allow 0.24.1

### DIFF
--- a/crates/opencascade/Cargo.toml
+++ b/crates/opencascade/Cargo.toml
@@ -3,12 +3,12 @@ name = "opencascade"
 description = "A high level Rust wrapper to build 3D models in code, using the OpenCascade CAD kernel"
 authors = ["Brian Schwind <brianmschwind@gmail.com>"]
 license = "LGPL-2.1"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/bschwind/opencascade-rs"
 
 [dependencies]
 cxx = "1"
 opencascade-sys = { version = "0.2", path = "../opencascade-sys" }
-glam = { version = "0.23", features = ["bytemuck"] }
+glam = { version = ">=0.23, <=0.24.1", features = ["bytemuck"] }
 thiserror = "1"

--- a/crates/viewer/Cargo.toml
+++ b/crates/viewer/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "viewer"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]
 bytemuck = { version = "1", features = ["derive"] }
 clap = { version = "4.3.19", features = ["derive"] }
 examples = { path = "../../examples" }
-glam = { version = "0.23", features = ["bytemuck"] }
-opencascade = { version = "0.2", path = "../opencascade" }
+glam = { version = ">=0.23, <=0.24.1", features = ["bytemuck"] }
+opencascade = { version = "0.2.1", path = "../opencascade" }
 simple-game = { git = "https://github.com/bschwind/simple-game.git" }
 smaa = "0.10"
 wgpu = "0.16"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "examples"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]
-opencascade = { version = "0.2", path = "../crates/opencascade" }
-glam = { version = "0.23", features = ["bytemuck"] }
+opencascade = { version = "0.2.1", path = "../crates/opencascade" }
+glam = { version = ">=0.23, <=0.24.1", features = ["bytemuck"] }


### PR DESCRIPTION
Trying to allow using latest version of `glam` to make it possible to use `opencascade-rs` with, for example, the latest `bevy@0.11.1`

At least examples seem to run correctly, but it's quite possible `simple-game` also needs updating to avoid duplicate dependency.