### PR TITLE
Update occt-sys to version 0.3

### DIFF
--- a/crates/occt-sys/Cargo.toml
+++ b/crates/occt-sys/Cargo.toml
@@ -3,9 +3,15 @@ name = "occt-sys"
 description = "Static build of the C++ OpenCascade CAD Kernel for use as a Rust dependency"
 authors = ["Brian Schwind <brianmschwind@gmail.com>", "Matěj Laitl <matej@laitl.cz>"]
 license = "LGPL-2.1"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 repository = "https://github.com/bschwind/opencascade-rs"
+
+# Adding an empty workspace table so occt-sys doesn't believe
+# it's in the parent workspace. This crate is excluded from
+# the top-level workspace because it takes quite awhile to
+# build and the crate doesn't change very often.
+[workspace]
 
 # Desperately trying to reduce the crate size here...
 # Sorted by file size

--- a/crates/occt-sys/build.rs
+++ b/crates/occt-sys/build.rs
@@ -29,12 +29,5 @@ fn main() {
         .define("INSTALL_DIR_INCLUDE", INCLUDE_DIR)
         .build();
 
-    println!(
-        "cargo:rustc-env=OCCT_LIB_PATH={}",
-        dst.join(LIB_DIR).to_str().expect("path is valid Unicode")
-    );
-    println!(
-        "cargo:rustc-env=OCCT_INCLUDE_PATH={}",
-        dst.join(INCLUDE_DIR).to_str().expect("path is valid Unicode")
-    );
+    println!("cargo:rustc-env=OCCT_PATH={}", dst.to_str().expect("path is valid Unicode"));
 }

--- a/crates/occt-sys/examples/print_paths.rs
+++ b/crates/occt-sys/examples/print_paths.rs
@@ -1,6 +1,3 @@
-use occt_sys::{occt_include_path, occt_lib_path};
-
 fn main() {
-    println!("occt_lib_path: {}", occt_lib_path().to_str().unwrap());
-    println!("occt_include_path: {}", occt_include_path().to_str().unwrap());
+    println!("occt_path: {}", occt_sys::occt_path().to_str().unwrap());
 }

--- a/crates/occt-sys/src/lib.rs
+++ b/crates/occt-sys/src/lib.rs
@@ -1,16 +1,9 @@
 use std::path::Path;
 
-/// Get path to OCCT library directory with built static libraries. To be used in build scripts
-/// with the `cargo:rustc-link-search` command.
+/// Get the path to the OCCT library installation directory to be
+/// used in build scripts.
 ///
 /// Only valid during build (`cargo clean` removes these files).
-pub fn occt_lib_path() -> &'static Path {
-    Path::new(env!("OCCT_LIB_PATH"))
-}
-
-/// Get path to OCCT header files.
-///
-/// Only valid during build (`cargo clean` removes these files).
-pub fn occt_include_path() -> &'static Path {
-    Path::new(env!("OCCT_INCLUDE_PATH"))
+pub fn occt_path() -> &'static Path {
+    Path::new(env!("OCCT_PATH"))
 }


### PR DESCRIPTION
Extracted from #87, to be published as occt-sys 0.3 before #87 is merged.

This just simplifies the crate to export `occt_path()` instead of `occt_lib_path()` and `occt_include_path()`