### PR TITLE
Variable Fillets

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -413,6 +413,10 @@ inline std::unique_ptr<gp_Dir> TColgp_Array1OfDir_Value(const TColgp_Array1OfDir
   return std::unique_ptr<gp_Dir>(new gp_Dir(array.Value(index)));
 }
 
+inline std::unique_ptr<gp_Pnt2d> TColgp_Array1OfPnt2d_Value(const TColgp_Array1OfPnt2d &array, Standard_Integer index) {
+  return std::unique_ptr<gp_Pnt2d>(new gp_Pnt2d(array.Value(index)));
+}
+
 inline void connect_edges_to_wires(Handle_TopTools_HSequenceOfShape &edges, const Standard_Real toler,
                                    const Standard_Boolean shared, Handle_TopTools_HSequenceOfShape &wires) {
   ShapeAnalysis_FreeBounds::ConnectEdgesToWires(edges, toler, shared, wires);

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -176,6 +176,7 @@ pub mod ffi {
             array: &TColgp_Array1OfPnt2d,
             index: i32,
         ) -> UniquePtr<gp_Pnt2d>;
+        pub fn SetValue(self: Pin<&mut TColgp_Array1OfPnt2d>, index: i32, item: &gp_Pnt2d);
 
         type TColgp_Array2OfPnt;
         #[cxx_name = "construct_unique"]

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -165,6 +165,18 @@ pub mod ffi {
             index: i32,
         ) -> UniquePtr<gp_Dir>;
 
+        type TColgp_Array1OfPnt2d;
+        #[cxx_name = "construct_unique"]
+        pub fn TColgp_Array1OfPnt2d_ctor(
+            lower_bound: i32,
+            upper_bound: i32,
+        ) -> UniquePtr<TColgp_Array1OfPnt2d>;
+        pub fn Length(self: &TColgp_Array1OfPnt2d) -> i32;
+        pub fn TColgp_Array1OfPnt2d_Value(
+            array: &TColgp_Array1OfPnt2d,
+            index: i32,
+        ) -> UniquePtr<gp_Pnt2d>;
+
         type TColgp_Array2OfPnt;
         #[cxx_name = "construct_unique"]
         pub fn TColgp_Array2OfPnt_ctor(
@@ -590,6 +602,14 @@ pub mod ffi {
 
         #[rust_name = "add_edge"]
         pub fn Add(self: Pin<&mut BRepFilletAPI_MakeFillet>, radius: f64, edge: &TopoDS_Edge);
+
+        #[rust_name = "variable_add_edge"]
+        pub fn Add(
+            self: Pin<&mut BRepFilletAPI_MakeFillet>,
+            radius_values: &TColgp_Array1OfPnt2d,
+            edge: &TopoDS_Edge,
+        );
+
         pub fn Shape(self: Pin<&mut BRepFilletAPI_MakeFillet>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepFilletAPI_MakeFillet>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepFilletAPI_MakeFillet) -> bool;

--- a/crates/opencascade/src/primitives.rs
+++ b/crates/opencascade/src/primitives.rs
@@ -195,3 +195,26 @@ impl Iterator for FaceIterator {
         }
     }
 }
+
+/// Given n and func, returns an iterator of (t, f(t)) values
+/// where t is in the range [0, 1].
+/// Note that n + 1 values are returned.
+pub fn approximate_function<F: FnMut(f64) -> f64>(
+    n: usize,
+    mut func: F,
+) -> impl Iterator<Item = (f64, f64)> {
+    let mut count = 0;
+
+    std::iter::from_fn(move || {
+        if count > n {
+            return None;
+        }
+
+        let t = count as f64 / n as f64;
+        count += 1;
+
+        let val = func(t);
+
+        Some((t, val))
+    })
+}

--- a/crates/opencascade/src/primitives.rs
+++ b/crates/opencascade/src/primitives.rs
@@ -1,5 +1,5 @@
 use cxx::UniquePtr;
-use glam::DVec3;
+use glam::{DVec2, DVec3};
 use opencascade_sys::ffi;
 
 mod boolean_shape;
@@ -89,6 +89,10 @@ impl<T: Into<Shape>> IntoShape for T {
 
 pub fn make_point(p: DVec3) -> UniquePtr<ffi::gp_Pnt> {
     ffi::new_point(p.x, p.y, p.z)
+}
+
+pub fn make_point2d(p: DVec2) -> UniquePtr<ffi::gp_Pnt2d> {
+    ffi::new_point_2d(p.x, p.y)
 }
 
 fn make_dir(p: DVec3) -> UniquePtr<ffi::gp_Dir> {

--- a/crates/opencascade/src/primitives/boolean_shape.rs
+++ b/crates/opencascade/src/primitives/boolean_shape.rs
@@ -33,6 +33,14 @@ impl BooleanShape {
     }
 
     #[must_use]
+    pub fn variable_fillet_new_edges(
+        &self,
+        radius_values: impl IntoIterator<Item = (f64, f64)>,
+    ) -> Shape {
+        self.shape.variable_fillet_edges(radius_values, &self.new_edges)
+    }
+
+    #[must_use]
     pub fn chamfer_new_edges(&self, distance: f64) -> Shape {
         self.shape.chamfer_edges(distance, &self.new_edges)
     }

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -95,6 +95,18 @@ impl Shape {
     }
 
     #[must_use]
+    pub fn variable_fillet_edge(
+        &self,
+        radius_values: impl IntoIterator<Item = (f64, f64)>,
+        edge: &Edge,
+    ) -> Self {
+        let mut make_fillet = ffi::BRepFilletAPI_MakeFillet_ctor(&self.inner);
+        make_fillet.pin_mut().add_edge(radius, &edge.inner);
+
+        Self::from_shape(make_fillet.pin_mut().Shape())
+    }
+
+    #[must_use]
     pub fn chamfer_edge(&self, distance: f64, edge: &Edge) -> Self {
         let mut make_chamfer = ffi::BRepFilletAPI_MakeChamfer_ctor(&self.inner);
         make_chamfer.pin_mut().add_edge(distance, &edge.inner);

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -88,10 +88,7 @@ impl Shape {
 
     #[must_use]
     pub fn fillet_edge(&self, radius: f64, edge: &Edge) -> Self {
-        let mut make_fillet = ffi::BRepFilletAPI_MakeFillet_ctor(&self.inner);
-        make_fillet.pin_mut().add_edge(radius, &edge.inner);
-
-        Self::from_shape(make_fillet.pin_mut().Shape())
+        self.fillet_edges(radius, [edge])
     }
 
     #[must_use]
@@ -100,25 +97,12 @@ impl Shape {
         radius_values: impl IntoIterator<Item = (f64, f64)>,
         edge: &Edge,
     ) -> Self {
-        let radius_values: Vec<_> = radius_values.into_iter().collect();
-        let mut array = ffi::TColgp_Array1OfPnt2d_ctor(1, radius_values.len() as i32);
-
-        for (index, (t, radius)) in radius_values.into_iter().enumerate() {
-            array.pin_mut().SetValue(index as i32 + 1, &make_point2d(dvec2(t, radius)));
-        }
-
-        let mut make_fillet = ffi::BRepFilletAPI_MakeFillet_ctor(&self.inner);
-        make_fillet.pin_mut().variable_add_edge(&array, &edge.inner);
-
-        Self::from_shape(make_fillet.pin_mut().Shape())
+        self.variable_fillet_edges(radius_values, [edge])
     }
 
     #[must_use]
     pub fn chamfer_edge(&self, distance: f64, edge: &Edge) -> Self {
-        let mut make_chamfer = ffi::BRepFilletAPI_MakeChamfer_ctor(&self.inner);
-        make_chamfer.pin_mut().add_edge(distance, &edge.inner);
-
-        Self::from_shape(make_chamfer.pin_mut().Shape())
+        self.chamfer_edges(distance, [edge])
     }
 
     #[must_use]

--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -50,6 +50,7 @@ enum Example {
     KeyboardCase,
     Keycap,
     RoundedChamfer,
+    VariableFillet,
 }
 
 impl Example {
@@ -63,6 +64,7 @@ impl Example {
             Example::KeyboardCase => examples::keyboard_case::shape(),
             Example::Keycap => examples::keycap::shape(),
             Example::RoundedChamfer => examples::rounded_chamfer::shape(),
+            Example::VariableFillet => examples::variable_fillet::shape(),
         }
     }
 }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -6,3 +6,4 @@ pub mod high_level_bottle;
 pub mod keyboard_case;
 pub mod keycap;
 pub mod rounded_chamfer;
+pub mod variable_fillet;

--- a/examples/src/variable_fillet.rs
+++ b/examples/src/variable_fillet.rs
@@ -1,18 +1,34 @@
 use glam::dvec3;
 use opencascade::{
-    primitives::{Direction, IntoShape, Shape},
+    primitives::{approximate_function, Direction, IntoShape, Shape},
     workplane::Workplane,
 };
 
 // Demonstrates a variable fillet radius along the edge of a cube.
 pub fn shape() -> Shape {
     let base = Workplane::xy().rect(50.0, 50.0);
-    let shape = base.to_face().extrude(dvec3(0.0, 0.0, 50.0));
-    let shape = shape.into_shape();
+    let mut shape = base.to_face().extrude(dvec3(0.0, 0.0, 50.0)).into_shape();
 
-    let right_edge = shape.faces().farthest(Direction::PosX).edges().next().unwrap();
-    shape.variable_fillet_edge(
+    let mut edges = shape.faces().farthest(Direction::PosX).edges();
+    let right_edge = edges.next().unwrap();
+    let another_edge = edges.next().unwrap();
+
+    // Manually define fillet radii at normalized 't' values (0-1), where
+    // t is 0 at the start of the edge, and 1 at the end of the edge.
+    shape = shape.variable_fillet_edge(
         [(0.0, 7.0), (0.2, 20.0), (0.5, 3.0), (0.8, 20.0), (1.0, 7.0)],
         &right_edge,
+    );
+
+    // Or define fillet radii by providing n, the number of radii to generate,
+    // and a function which accepts t and returns a radius for the fillet at t.
+    let num_radii = 5;
+    shape.variable_fillet_edge(
+        approximate_function(num_radii, |t| {
+            let t_squared = t * t;
+            let val = t_squared / (2.0 * (t_squared - t) + 1.0);
+            (val + 0.2) * 10.0
+        }),
+        &another_edge,
     )
 }

--- a/examples/src/variable_fillet.rs
+++ b/examples/src/variable_fillet.rs
@@ -8,13 +8,11 @@ use opencascade::{
 pub fn shape() -> Shape {
     let base = Workplane::xy().rect(50.0, 50.0);
     let shape = base.to_face().extrude(dvec3(0.0, 0.0, 50.0));
-    let mut shape = shape.into_shape();
+    let shape = shape.into_shape();
 
     let right_edge = shape.faces().farthest(Direction::PosX).edges().next().unwrap();
     shape.variable_fillet_edge(
         [(0.0, 7.0), (0.2, 20.0), (0.5, 3.0), (0.8, 20.0), (1.0, 7.0)],
         &right_edge,
-    );
-
-    shape
+    )
 }

--- a/examples/src/variable_fillet.rs
+++ b/examples/src/variable_fillet.rs
@@ -9,26 +9,37 @@ pub fn shape() -> Shape {
     let base = Workplane::xy().rect(50.0, 50.0);
     let mut shape = base.to_face().extrude(dvec3(0.0, 0.0, 50.0)).into_shape();
 
-    let mut edges = shape.faces().farthest(Direction::PosX).edges();
-    let right_edge = edges.next().unwrap();
-    let another_edge = edges.next().unwrap();
+    let mut right_face_edges = shape.faces().farthest(Direction::PosX).edges();
+    let first_edge = right_face_edges.next().unwrap();
+    let another_edge = right_face_edges.next().unwrap();
 
     // Manually define fillet radii at normalized 't' values (0-1), where
     // t is 0 at the start of the edge, and 1 at the end of the edge.
     shape = shape.variable_fillet_edge(
         [(0.0, 7.0), (0.2, 20.0), (0.5, 3.0), (0.8, 20.0), (1.0, 7.0)],
-        &right_edge,
+        &first_edge,
     );
 
     // Or define fillet radii by providing n, the number of radii to generate,
     // and a function which accepts t and returns a radius for the fillet at t.
     let num_radii = 5;
-    shape.variable_fillet_edge(
+    shape = shape.variable_fillet_edge(
         approximate_function(num_radii, |t| {
             let t_squared = t * t;
             let val = t_squared / (2.0 * (t_squared - t) + 1.0);
             (val + 0.2) * 10.0
         }),
         &another_edge,
+    );
+
+    let left_face_edges = shape.faces().farthest(Direction::NegX).edges();
+
+    // Fillet all edges on the left face with a rough bell curve, for fun.
+    shape.variable_fillet_edges(
+        approximate_function(num_radii, |t| {
+            let val = ((2.0 * std::f64::consts::PI * (t - 1.0 / 4.0)).sin() + 1.0) / 2.0;
+            val * 10.0
+        }),
+        left_face_edges,
     )
 }

--- a/examples/src/variable_fillet.rs
+++ b/examples/src/variable_fillet.rs
@@ -1,0 +1,20 @@
+use glam::dvec3;
+use opencascade::{
+    primitives::{Direction, IntoShape, Shape},
+    workplane::Workplane,
+};
+
+// Demonstrates a variable fillet radius along the edge of a cube.
+pub fn shape() -> Shape {
+    let base = Workplane::xy().rect(50.0, 50.0);
+    let shape = base.to_face().extrude(dvec3(0.0, 0.0, 50.0));
+    let mut shape = shape.into_shape();
+
+    let right_edge = shape.faces().farthest(Direction::PosX).edges().next().unwrap();
+    shape.variable_fillet_edge(
+        [(0.0, 7.0), (0.2, 20.0), (0.5, 3.0), (0.8, 20.0), (1.0, 7.0)],
+        &right_edge,
+    );
+
+    shape
+}


### PR DESCRIPTION
Closes #38

- [x] Support user-defined functions with N sample points

Try it out with

```
$ cargo run --release --no-default-features --bin viewer -- variable-fillet
```


https://github.com/bschwind/opencascade-rs/assets/458432/6b5032f8-e4d4-476e-808a-c1b2ce04489c

<img width="922" alt="Screen Shot 2023-08-27 at 10 31 30 PM" src="https://github.com/bschwind/opencascade-rs/assets/458432/3060ccf7-7c84-4e53-886d-2d726d4bc670">
