### PR TITLE
Add creating wire from ordered points

### DIFF
--- a/crates/opencascade/src/adhoc.rs
+++ b/crates/opencascade/src/adhoc.rs
@@ -42,9 +42,7 @@ impl AdHocShape {
     /// Purposefully underpowered for now, this simply takes a list of points,
     /// creates a face out of them, and then extrudes it by h in the positive Z
     /// direction.
-    pub fn extrude_polygon(points: &[DVec3], h: f64) -> Solid {
-        assert!(points.len() >= 3);
-
+    pub fn extrude_polygon(points: impl IntoIterator<Item = DVec3>, h: f64) -> Solid {
         let wire = Wire::from_ordered_points(points);
         Face::from_wire(&wire).extrude(dvec3(0.0, 0.0, h))
     }

--- a/crates/opencascade/src/adhoc.rs
+++ b/crates/opencascade/src/adhoc.rs
@@ -1,4 +1,7 @@
-use crate::primitives::{Face, Shape, Solid, Wire};
+use crate::{
+    primitives::{Face, Shape, Solid, Wire},
+    Error,
+};
 use glam::{dvec3, DVec3};
 use opencascade_sys::ffi;
 
@@ -42,9 +45,12 @@ impl AdHocShape {
     /// Purposefully underpowered for now, this simply takes a list of points,
     /// creates a face out of them, and then extrudes it by h in the positive Z
     /// direction.
-    pub fn extrude_polygon(points: impl IntoIterator<Item = DVec3>, h: f64) -> Solid {
-        let wire = Wire::from_ordered_points(points);
-        Face::from_wire(&wire).extrude(dvec3(0.0, 0.0, h))
+    pub fn extrude_polygon(
+        points: impl IntoIterator<Item = DVec3>,
+        h: f64,
+    ) -> Result<Solid, Error> {
+        let wire = Wire::from_ordered_points(points)?;
+        Ok(Face::from_wire(&wire).extrude(dvec3(0.0, 0.0, h)))
     }
 
     /// Drills a cylindrical hole starting at point p, pointing down the Z axis

--- a/crates/opencascade/src/adhoc.rs
+++ b/crates/opencascade/src/adhoc.rs
@@ -1,6 +1,5 @@
-use crate::primitives::Shape;
-use cxx::UniquePtr;
-use glam::DVec3;
+use crate::primitives::{Face, Shape, Solid, Wire};
+use glam::{dvec3, DVec3};
 use opencascade_sys::ffi;
 
 /// Collections of helper functions for the [`Shape`] struct that provides an "ad-hoc"
@@ -43,43 +42,11 @@ impl AdHocShape {
     /// Purposefully underpowered for now, this simply takes a list of points,
     /// creates a face out of them, and then extrudes it by h in the positive Z
     /// direction.
-    pub fn extrude_polygon(points: &[DVec3], h: f64) -> Shape {
+    pub fn extrude_polygon(points: &[DVec3], h: f64) -> Solid {
         assert!(points.len() >= 3);
 
-        let mut make_wire = ffi::BRepBuilderAPI_MakeWire_ctor();
-
-        let add_segment =
-            |p1: DVec3, p2: DVec3, make_wire: &mut UniquePtr<ffi::BRepBuilderAPI_MakeWire>| {
-                let p1 = ffi::new_point(p1.x, p1.y, p1.z);
-                let p2 = ffi::new_point(p2.x, p2.y, p2.z);
-
-                let segment = ffi::GC_MakeSegment_point_point(&p1, &p2);
-                let mut edge = ffi::BRepBuilderAPI_MakeEdge_HandleGeomCurve(
-                    &ffi::new_HandleGeomCurve_from_HandleGeom_TrimmedCurve(
-                        &ffi::GC_MakeSegment_Value(&segment),
-                    ),
-                );
-
-                make_wire.pin_mut().add_edge(edge.pin_mut().Edge());
-            };
-
-        for window in points.windows(2) {
-            add_segment(window[0], window[1], &mut make_wire);
-        }
-
-        add_segment(*points.last().unwrap(), points[0], &mut make_wire);
-
-        let wire_profile = make_wire.pin_mut().Wire();
-        let mut face_profile = ffi::BRepBuilderAPI_MakeFace_wire(wire_profile, false);
-        let prism_vec = ffi::new_vec(0.0, 0.0, h);
-        let mut extrusion = ffi::BRepPrimAPI_MakePrism_ctor(
-            face_profile.pin_mut().Shape(),
-            &prism_vec,
-            false,
-            true,
-        );
-
-        Shape::from_shape(extrusion.pin_mut().Shape())
+        let wire = Wire::from_ordered_points(points);
+        Face::from_wire(&wire).extrude(dvec3(0.0, 0.0, h))
     }
 
     /// Drills a cylindrical hole starting at point p, pointing down the Z axis

--- a/crates/opencascade/src/lib.rs
+++ b/crates/opencascade/src/lib.rs
@@ -18,4 +18,6 @@ pub enum Error {
     TriangulationFailed,
     #[error("encountered a face with no triangulation")]
     UntriangulatedFace,
+    #[error("at least 3 points are required for creating a wire")]
+    NotEnoughPoints,
 }

--- a/crates/opencascade/src/lib.rs
+++ b/crates/opencascade/src/lib.rs
@@ -18,6 +18,6 @@ pub enum Error {
     TriangulationFailed,
     #[error("encountered a face with no triangulation")]
     UntriangulatedFace,
-    #[error("at least 3 points are required for creating a wire")]
+    #[error("at least 2 points are required for creating a wire")]
     NotEnoughPoints,
 }

--- a/crates/opencascade/src/primitives/wire.rs
+++ b/crates/opencascade/src/primitives/wire.rs
@@ -45,7 +45,8 @@ impl Wire {
         Self::from_wire(make_wire.pin_mut().Wire())
     }
 
-    pub fn from_ordered_points(points: &[DVec3]) -> Self {
+    pub fn from_ordered_points(points: impl IntoIterator<Item = DVec3>) -> Self {
+        let points: Vec<_> = points.into_iter().collect();
         let mut make_wire = ffi::BRepBuilderAPI_MakeWire_ctor();
 
         if let (Some(first), Some(last)) = (points.first(), points.last()) {

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -251,7 +251,7 @@ fn usb_connector_cutout() -> Shape {
 // extend forward into the case.
 fn pcb_usb_overhang() -> Shape {
     AdHocShape::extrude_polygon(
-        &[
+        [
             DVec3::new(19.05, 0.0, PCB_BOTTOM_Z),
             DVec3::new(21.431, 2.381, PCB_BOTTOM_Z),
             DVec3::new(30.596, 2.381, PCB_BOTTOM_Z),

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -259,6 +259,7 @@ fn pcb_usb_overhang() -> Shape {
         ],
         PCB_THICKNESS + 0.5,
     )
+    .unwrap()
     .into()
 }
 

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -259,6 +259,7 @@ fn pcb_usb_overhang() -> Shape {
         ],
         PCB_THICKNESS + 0.5,
     )
+    .into()
 }
 
 pub fn shape() -> Shape {


### PR DESCRIPTION
This PR adds the option to create a wire from a list of ordered points. It also uses this new function for simplifying `extrude_polygon()` in the ad-hoc API.
