### PR TITLE
add Shell::loft(wires) and underlying machinery

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -232,6 +232,7 @@ inline const TopoDS_Vertex &TopoDS_cast_to_vertex(const TopoDS_Shape &shape) { r
 inline const TopoDS_Edge &TopoDS_cast_to_edge(const TopoDS_Shape &shape) { return TopoDS::Edge(shape); }
 inline const TopoDS_Wire &TopoDS_cast_to_wire(const TopoDS_Shape &shape) { return TopoDS::Wire(shape); }
 inline const TopoDS_Face &TopoDS_cast_to_face(const TopoDS_Shape &shape) { return TopoDS::Face(shape); }
+inline const TopoDS_Shell &TopoDS_cast_to_shell(const TopoDS_Shape &shape) { return TopoDS::Shell(shape); }
 inline const TopoDS_Solid &TopoDS_cast_to_solid(const TopoDS_Shape &shape) { return TopoDS::Solid(shape); }
 inline const TopoDS_Compound &TopoDS_cast_to_compound(const TopoDS_Shape &shape) { return TopoDS::Compound(shape); }
 
@@ -239,6 +240,7 @@ inline const TopoDS_Shape &cast_vertex_to_shape(const TopoDS_Vertex &vertex) { r
 inline const TopoDS_Shape &cast_edge_to_shape(const TopoDS_Edge &edge) { return edge; }
 inline const TopoDS_Shape &cast_wire_to_shape(const TopoDS_Wire &wire) { return wire; }
 inline const TopoDS_Shape &cast_face_to_shape(const TopoDS_Face &face) { return face; }
+inline const TopoDS_Shape &cast_shell_to_shape(const TopoDS_Shell &shell) { return shell; }
 inline const TopoDS_Shape &cast_solid_to_shape(const TopoDS_Solid &solid) { return solid; }
 inline const TopoDS_Shape &cast_compound_to_shape(const TopoDS_Compound &compound) { return compound; }
 

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -337,6 +337,7 @@ pub mod ffi {
         pub fn cast_edge_to_shape(wire: &TopoDS_Edge) -> &TopoDS_Shape;
         pub fn cast_wire_to_shape(wire: &TopoDS_Wire) -> &TopoDS_Shape;
         pub fn cast_face_to_shape(wire: &TopoDS_Face) -> &TopoDS_Shape;
+        pub fn cast_shell_to_shape(wire: &TopoDS_Shell) -> &TopoDS_Shape;
         pub fn cast_solid_to_shape(wire: &TopoDS_Solid) -> &TopoDS_Shape;
         pub fn cast_compound_to_shape(wire: &TopoDS_Compound) -> &TopoDS_Shape;
 
@@ -344,6 +345,7 @@ pub mod ffi {
         pub fn TopoDS_cast_to_wire(shape: &TopoDS_Shape) -> &TopoDS_Wire;
         pub fn TopoDS_cast_to_edge(shape: &TopoDS_Shape) -> &TopoDS_Edge;
         pub fn TopoDS_cast_to_face(shape: &TopoDS_Shape) -> &TopoDS_Face;
+        pub fn TopoDS_cast_to_shell(shape: &TopoDS_Shape) -> &TopoDS_Shell;
         pub fn TopoDS_cast_to_solid(shape: &TopoDS_Shape) -> &TopoDS_Solid;
         pub fn TopoDS_cast_to_compound(shape: &TopoDS_Shape) -> &TopoDS_Compound;
 

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -2,7 +2,7 @@ use crate::{
     mesh::{Mesh, Mesher},
     primitives::{
         make_dir, make_point, make_point2d, make_vec, BooleanShape, Compound, Edge, EdgeIterator,
-        Face, FaceIterator, ShapeType, Solid, Vertex, Wire,
+        Face, FaceIterator, ShapeType, Shell, Solid, Vertex, Wire,
     },
     Error,
 };
@@ -48,6 +48,14 @@ impl From<Wire> for Shape {
 impl From<Face> for Shape {
     fn from(face: Face) -> Self {
         let shape = ffi::cast_face_to_shape(&face.inner);
+
+        Self::from_shape(shape)
+    }
+}
+
+impl From<Shell> for Shape {
+    fn from(shell: Shell) -> Self {
+        let shape = ffi::cast_shell_to_shape(&shell.inner);
 
         Self::from_shape(shape)
     }

--- a/crates/opencascade/src/primitives/shell.rs
+++ b/crates/opencascade/src/primitives/shell.rs
@@ -28,7 +28,7 @@ impl Shell {
             make_loft.pin_mut().AddWire(&wire.as_ref().inner);
         }
 
-        // Set to CheckCompatibility to `true` to avoid twisted results.
+        // Set CheckCompatibility to `true` to avoid twisted results.
         make_loft.pin_mut().CheckCompatibility(true);
 
         let shape = make_loft.pin_mut().Shape();

--- a/crates/opencascade/src/primitives/shell.rs
+++ b/crates/opencascade/src/primitives/shell.rs
@@ -1,12 +1,39 @@
 use cxx::UniquePtr;
 use opencascade_sys::ffi;
 
+use crate::primitives::Wire;
+
 pub struct Shell {
-    pub(crate) _inner: UniquePtr<ffi::TopoDS_Shell>,
+    pub(crate) inner: UniquePtr<ffi::TopoDS_Shell>,
 }
 
 impl AsRef<Shell> for Shell {
     fn as_ref(&self) -> &Shell {
         self
+    }
+}
+
+impl Shell {
+    pub(crate) fn from_shell(shell: &ffi::TopoDS_Shell) -> Self {
+        let inner = ffi::TopoDS_Shell_to_owned(shell);
+
+        Self { inner }
+    }
+
+    pub fn loft<T: AsRef<Wire>>(wires: impl IntoIterator<Item = T>) -> Self {
+        let is_solid = false;
+        let mut make_loft = ffi::BRepOffsetAPI_ThruSections_ctor(is_solid);
+
+        for wire in wires.into_iter() {
+            make_loft.pin_mut().AddWire(&wire.as_ref().inner);
+        }
+
+        // Set to CheckCompatibility to `true` to avoid twisted results.
+        make_loft.pin_mut().CheckCompatibility(true);
+
+        let shape = make_loft.pin_mut().Shape();
+        let shell = ffi::TopoDS_cast_to_shell(shape);
+
+        Self::from_shell(shell)
     }
 }


### PR DESCRIPTION
Adds `Shell::loft(wires)` and underlying machinery.
Essentially copy-paste of `Solid::loft(wires)` with a tiny change.