### PR TITLE
Re-add the intersect function

### DIFF
--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -792,6 +792,7 @@ pub mod ffi {
         pub fn Shape(self: Pin<&mut BRepAlgoAPI_Common>) -> &TopoDS_Shape;
         pub fn Build(self: Pin<&mut BRepAlgoAPI_Common>, progress: &Message_ProgressRange);
         pub fn IsDone(self: &BRepAlgoAPI_Common) -> bool;
+        pub fn SectionEdges(self: Pin<&mut BRepAlgoAPI_Common>) -> &TopTools_ListOfShape;
 
         type BRepAlgoAPI_Section;
 

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -479,6 +479,23 @@ impl Shape {
         BooleanShape { shape, new_edges }
     }
 
+    #[must_use]
+    pub fn intersect(&self, other: &Shape) -> BooleanShape {
+        let mut fuse_operation = ffi::BRepAlgoAPI_Common_ctor(&self.inner, &other.inner);
+        let edge_list = fuse_operation.pin_mut().SectionEdges();
+        let vec = ffi::shape_list_to_vector(edge_list);
+
+        let mut new_edges = vec![];
+        for shape in vec.iter() {
+            let edge = ffi::TopoDS_cast_to_edge(shape);
+            new_edges.push(Edge::from_edge(edge));
+        }
+
+        let shape = Self::from_shape(fuse_operation.pin_mut().Shape());
+
+        BooleanShape { shape, new_edges }
+    }
+
     pub fn write_stl<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
         self.write_stl_with_tolerance(path, 0.001)
     }


### PR DESCRIPTION
This got accidentally removed [here](https://github.com/bschwind/opencascade-rs/commit/cbd65b76d5c19b1757408d5274252063af6a3e75#diff-16323c223ae799d04b844e0fb721dc1f17cb7449454330d3c8a92bdf180b45f6L196)