### PR TITLE
add make solid and shell constructors

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -8,6 +8,7 @@
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepBuilderAPI_MakeShapeOnMesh.hxx>
+#include <BRepBuilderAPI_MakeSolid.hxx>
 #include <BRepBuilderAPI_MakeVertex.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepBuilderAPI_Transform.hxx>
@@ -255,6 +256,8 @@ inline const TopoDS_Shape &cast_compound_to_shape(const TopoDS_Compound &compoun
 inline std::unique_ptr<TopoDS_Shape> TopoDS_Compound_as_shape(std::unique_ptr<TopoDS_Compound> compound) {
   return compound;
 }
+
+inline std::unique_ptr<TopoDS_Shape> TopoDS_Shell_as_shape(std::unique_ptr<TopoDS_Shell> shell) { return shell; }
 
 inline const TopoDS_Builder &BRep_Builder_upcast_to_topods_builder(const BRep_Builder &builder) { return builder; }
 

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -279,6 +279,11 @@ inline std::unique_ptr<gp_Trsf> TopLoc_Location_Transformation(const TopLoc_Loca
   return std::unique_ptr<gp_Trsf>(new gp_Trsf(location.Transformation()));
 }
 
+inline std::unique_ptr<Handle_Poly_Triangulation>
+Handle_Poly_Triangulation_ctor(const Poly_Triangulation &triangulation) {
+  return std::unique_ptr<Handle_Poly_Triangulation>(new Handle_Poly_Triangulation(&triangulation));
+}
+
 inline std::unique_ptr<Handle_Poly_Triangulation> BRep_Tool_Triangulation(const TopoDS_Face &face,
                                                                           TopLoc_Location &location) {
   return std::unique_ptr<Handle_Poly_Triangulation>(

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -426,6 +426,8 @@ pub mod ffi {
             compound: UniquePtr<TopoDS_Compound>,
         ) -> UniquePtr<TopoDS_Shape>;
 
+        pub fn TopoDS_Shell_as_shape(shell: UniquePtr<TopoDS_Shell>) -> UniquePtr<TopoDS_Shape>;
+
         type BRep_Builder;
         type TopoDS_Builder;
 
@@ -433,10 +435,14 @@ pub mod ffi {
         pub fn TopoDS_Compound_ctor() -> UniquePtr<TopoDS_Compound>;
 
         #[cxx_name = "construct_unique"]
+        pub fn TopoDS_Shell_ctor() -> UniquePtr<TopoDS_Shell>;
+
+        #[cxx_name = "construct_unique"]
         pub fn BRep_Builder_ctor() -> UniquePtr<BRep_Builder>;
 
         pub fn BRep_Builder_upcast_to_topods_builder(builder: &BRep_Builder) -> &TopoDS_Builder;
         pub fn MakeCompound(self: &TopoDS_Builder, compound: Pin<&mut TopoDS_Compound>);
+        pub fn MakeShell(self: &TopoDS_Builder, compound: Pin<&mut TopoDS_Shell>);
         pub fn Add(self: &TopoDS_Builder, shape: Pin<&mut TopoDS_Shape>, compound: &TopoDS_Shape);
 
         // BRepBuilder
@@ -907,6 +913,17 @@ pub mod ffi {
         #[cxx_name = "SetTranslationPart"]
         pub fn set_translation_vec(self: Pin<&mut gp_Trsf>, translation: &gp_Vec);
 
+        type BRepBuilderAPI_MakeSolid;
+
+        #[cxx_name = "construct_unique"]
+        pub fn BRepBuilderAPI_MakeSolid_ctor(
+            shell: &TopoDS_Shell,
+        ) -> UniquePtr<BRepBuilderAPI_MakeSolid>;
+
+        pub fn Shape(self: Pin<&mut BRepBuilderAPI_MakeSolid>) -> &TopoDS_Shape;
+        pub fn Build(self: Pin<&mut BRepBuilderAPI_MakeSolid>, progress: &Message_ProgressRange);
+        pub fn IsDone(self: &BRepBuilderAPI_MakeSolid) -> bool;
+
         type BRepBuilderAPI_MakeShapeOnMesh;
 
         #[cxx_name = "construct_unique"]
@@ -1079,9 +1096,12 @@ pub mod ffi {
         pub fn TopLoc_Location_Transformation(location: &TopLoc_Location) -> UniquePtr<gp_Trsf>;
 
         type Handle_Poly_Triangulation;
+
+        /// # Safety
+        /// This method is safe assuming that `triangulation` points to a valid constructed object or is a null pointer.
         #[cxx_name = "construct_unique"]
-        pub fn Handle_Poly_Triangulation_ctor(
-            triangulation: &Handle_Poly_Triangulation,
+        pub unsafe fn Handle_Poly_Triangulation_ctor(
+            triangulation: *const Poly_Triangulation,
         ) -> UniquePtr<Handle_Poly_Triangulation>;
 
         pub fn IsNull(self: &Handle_Poly_Triangulation) -> bool;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1097,11 +1097,8 @@ pub mod ffi {
 
         type Handle_Poly_Triangulation;
 
-        /// # Safety
-        /// This method is safe assuming that `triangulation` points to a valid constructed object or is a null pointer.
-        #[cxx_name = "construct_unique"]
-        pub unsafe fn Handle_Poly_Triangulation_ctor(
-            triangulation: *const Poly_Triangulation,
+        pub fn Handle_Poly_Triangulation_ctor(
+            triangulation: &Poly_Triangulation,
         ) -> UniquePtr<Handle_Poly_Triangulation>;
 
         pub fn IsNull(self: &Handle_Poly_Triangulation) -> bool;


### PR DESCRIPTION
Using the shape constructed from a Triangulation. Its possible to build and shell and solid via the `TopoDS_Builder` API and use it as a full BRep object. 