### PR TITLE
rerun build script if env var changes

### DIFF
--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -76,6 +76,8 @@ struct OcctConfig {
 impl OcctConfig {
     /// Find OpenCASCADE library using cmake
     fn detect() -> Self {
+        println!("cargo:rerun-if-env-changed=DEP_OCCT_ROOT");
+
         // Add path to builtin OCCT
         #[cfg(feature = "builtin")]
         {


### PR DESCRIPTION
Rerun the `opencascade-sys` build script when `DEP_OCCT_ROOT` changes. Removing the need to run `cargo clean` every time that value is modified. 