### PR TITLE
fix: double free segfault when using Handle_Poly_Triangulation_ctor

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -280,8 +280,8 @@ inline std::unique_ptr<gp_Trsf> TopLoc_Location_Transformation(const TopLoc_Loca
 }
 
 inline std::unique_ptr<Handle_Poly_Triangulation>
-Handle_Poly_Triangulation_ctor(const Poly_Triangulation &triangulation) {
-  return std::unique_ptr<Handle_Poly_Triangulation>(new Handle_Poly_Triangulation(&triangulation));
+Handle_Poly_Triangulation_ctor(std::unique_ptr<Poly_Triangulation> triangulation) {
+  return std::unique_ptr<Handle_Poly_Triangulation>(new Handle_Poly_Triangulation(triangulation.release()));
 }
 
 inline std::unique_ptr<Handle_Poly_Triangulation> BRep_Tool_Triangulation(const TopoDS_Face &face,

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1098,7 +1098,7 @@ pub mod ffi {
         type Handle_Poly_Triangulation;
 
         pub fn Handle_Poly_Triangulation_ctor(
-            triangulation: &Poly_Triangulation,
+            triangulation: UniquePtr<Poly_Triangulation>,
         ) -> UniquePtr<Handle_Poly_Triangulation>;
 
         pub fn IsNull(self: &Handle_Poly_Triangulation) -> bool;


### PR DESCRIPTION
Handle_Poly_Triangulation_ctor caused a segfault since the underlying Triangulation would be freed twice. Once when the new handle was dropped and once when the UniquePtr was dropped. By passing ownership to the triangulation this is fixed. 