### PR TITLE
fix: emscripten unable to find OCCT

### DIFF
--- a/crates/opencascade-sys/OCCT/CMakeLists.txt
+++ b/crates/opencascade-sys/OCCT/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
 project (OpenCASCADEPackageConfig)
+
+# Fix for WASM: https://github.com/emscripten-core/emscripten/issues/19243
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE "BOTH" CACHE PATH "")
+
 find_package (OpenCASCADE REQUIRED)
 
 file (WRITE ${CMAKE_BINARY_DIR}/occ_info.txt


### PR DESCRIPTION
When compiling for WASM. The new build system fails to find OCCT. This is due to a bug in emscripten and there is a work around.

https://github.com/emscripten-core/emscripten/issues/19243