### PR TITLE
Toggle hidden-line drawing with the X key in the viewer app

### DIFF
--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -290,12 +290,18 @@ impl GameApp for ViewerApp {
                 self.camera.zoom(-zoom_delta);
             },
             WindowEvent::KeyboardInput {
-                event: KeyEvent { physical_key: PhysicalKey::Code(key_code), .. },
+                event:
+                    KeyEvent {
+                        physical_key: PhysicalKey::Code(key_code),
+                        state: ElementState::Pressed,
+                        ..
+                    },
                 ..
             } => match key_code {
                 KeyCode::Escape => window_target.exit(),
                 KeyCode::KeyP => self.camera.use_perspective(),
                 KeyCode::KeyO => self.camera.use_orthographic(),
+                KeyCode::KeyX => self.line_drawer.toggle_back_edge_drawing(),
                 _ => {},
             },
             _ => {},


### PR DESCRIPTION
<img width="868" alt="Screen Shot 2024-01-15 at 11 47 47" src="https://github.com/bschwind/opencascade-rs/assets/458432/5fef2f53-e977-459f-a04f-48b1cff70923">
<img width="868" alt="Screen Shot 2024-01-15 at 11 47 50" src="https://github.com/bschwind/opencascade-rs/assets/458432/c2acddb5-92a0-47ec-b240-84c131866da0">
