### PR TITLE
fix: allow cross compilation under builtin flag

### DIFF
--- a/.github/workflows/occt.yml
+++ b/.github/workflows/occt.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: 4
   build-wasm:
-    name: Cargo Build OCCT WASM
+    name: Cargo Build OCCT (wasm32)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/occt.yml
+++ b/.github/workflows/occt.yml
@@ -1,0 +1,42 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+name: Cargo Build OCCT
+
+jobs:
+  build:
+    name: Cargo Build OCCT
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Cache Rust Dependencies
+        uses: Swatinem/rust-cache@v2
+      - run: cargo build -p opencascade-sys --features builtin
+  build-wasm:
+    name: Cargo Build OCCT WASM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - uses: lovasoa/setup-emscripten@master
+        with:
+          emscripten-version: '3.1.51'
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-emscripten
+      - name: Cache Rust Dependencies
+        uses: Swatinem/rust-cache@v2
+      - run: cargo build -p opencascade-sys --features builtin --target wasm32-unknown-emscripten

--- a/.github/workflows/occt.yml
+++ b/.github/workflows/occt.yml
@@ -31,8 +31,6 @@ jobs:
         with:
           submodules: "recursive"
       - uses: lovasoa/setup-emscripten@master
-        with:
-          emscripten-version: '3.1.39'
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/occt.yml
+++ b/.github/workflows/occt.yml
@@ -1,8 +1,8 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
+    paths:
+      - 'crates/occt-sys/**'
+      - 'crates/opencascade-sys/**'
 
 name: Cargo Build OCCT
 

--- a/.github/workflows/occt.yml
+++ b/.github/workflows/occt.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: "recursive"
-      - uses: lovasoa/setup-emscripten@master
+      - uses: mymindstorm/setup-emsdk@v13
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/occt.yml
+++ b/.github/workflows/occt.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Cache Rust Dependencies
         uses: Swatinem/rust-cache@v2
       - run: cargo build -p opencascade-sys --features builtin -vv
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: 4
   build-wasm:
     name: Cargo Build OCCT WASM
     runs-on: ubuntu-latest
@@ -42,3 +44,5 @@ jobs:
       - name: Cache Rust Dependencies
         uses: Swatinem/rust-cache@v2
       - run: cargo build -p opencascade-sys --features builtin --target wasm32-unknown-emscripten -vv
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: 4

--- a/.github/workflows/occt.yml
+++ b/.github/workflows/occt.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: "recursive"
       - uses: lovasoa/setup-emscripten@master
         with:
-          emscripten-version: '3.1.51'
+          emscripten-version: '3.1.39'
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/occt.yml
+++ b/.github/workflows/occt.yml
@@ -6,6 +6,10 @@ on:
 
 name: Cargo Build OCCT
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Cargo Build OCCT
@@ -22,7 +26,7 @@ jobs:
           toolchain: stable
       - name: Cache Rust Dependencies
         uses: Swatinem/rust-cache@v2
-      - run: cargo build -p opencascade-sys --features builtin
+      - run: cargo build -p opencascade-sys --features builtin -vv
   build-wasm:
     name: Cargo Build OCCT WASM
     runs-on: ubuntu-latest
@@ -37,4 +41,4 @@ jobs:
           targets: wasm32-unknown-emscripten
       - name: Cache Rust Dependencies
         uses: Swatinem/rust-cache@v2
-      - run: cargo build -p opencascade-sys --features builtin --target wasm32-unknown-emscripten
+      - run: cargo build -p opencascade-sys --features builtin --target wasm32-unknown-emscripten -vv

--- a/crates/occt-sys/Cargo.toml
+++ b/crates/occt-sys/Cargo.toml
@@ -3,7 +3,7 @@ name = "occt-sys"
 description = "Static build of the C++ OpenCascade CAD Kernel for use as a Rust dependency"
 authors = ["Brian Schwind <brianmschwind@gmail.com>", "Matěj Laitl <matej@laitl.cz>"]
 license = "LGPL-2.1"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/bschwind/opencascade-rs"
 
@@ -148,7 +148,7 @@ exclude = [
     # "OCCT/src/BRepCheck/*",
     # "OCCT/src/MAT2d/*",
     "OCCT/src/ExpToCasExe/*",
-    # "OCCT/src/STEPControl/*",
+    "OCCT/src/STEPControl/*",
     # "OCCT/src/GeomPlate/*",
     # "OCCT/src/IntCurveSurface/*",
     # "OCCT/src/GeomLib/*",
@@ -409,12 +409,4 @@ exclude = [
 ]
 
 [dependencies]
-
-[build-dependencies]
 cmake = "0.1"
-
-# Adding an empty workspace table so occt-sys doesn't believe
-# it's in the parent workspace. This crate is excluded from
-# the top-level workspace because it takes quite awhile to
-# build and the crate doesn't change very often.
-[workspace]

--- a/crates/occt-sys/build.rs
+++ b/crates/occt-sys/build.rs
@@ -1,33 +1,12 @@
-const LIB_DIR: &str = "lib";
-const INCLUDE_DIR: &str = "include";
+use std::{env::var, path::Path};
 
 fn main() {
-    let current_dir = std::env::current_dir().expect("Should have a 'current' directory");
-    let patch_dir = current_dir.join("patch");
-
-    let dst = cmake::Config::new("OCCT")
-        .define("BUILD_PATCH", patch_dir)
-        .define("BUILD_LIBRARY_TYPE", "Static")
-        .define("BUILD_MODULE_ApplicationFramework", "FALSE")
-        .define("BUILD_MODULE_Draw", "FALSE")
-        .define("USE_D3D", "FALSE")
-        .define("USE_DRACO", "FALSE")
-        .define("USE_EIGEN", "FALSE")
-        .define("USE_FFMPEG", "FALSE")
-        .define("USE_FREEIMAGE", "FALSE")
-        .define("USE_FREETYPE", "FALSE")
-        .define("USE_GLES2", "FALSE")
-        .define("USE_OPENGL", "FALSE")
-        .define("USE_OPENVR", "FALSE")
-        .define("USE_RAPIDJSON", "FALSE")
-        .define("USE_TBB", "FALSE")
-        .define("USE_TCL", "FALSE")
-        .define("USE_TK", "FALSE")
-        .define("USE_VTK", "FALSE")
-        .define("USE_XLIB", "FALSE")
-        .define("INSTALL_DIR_LIB", LIB_DIR)
-        .define("INSTALL_DIR_INCLUDE", INCLUDE_DIR)
-        .build();
-
-    println!("cargo:rustc-env=OCCT_PATH={}", dst.to_str().expect("path is valid Unicode"));
+    println!(
+        "cargo:rustc-env=OCCT_SRC_DIR={}",
+        Path::new(&var("CARGO_MANIFEST_DIR").unwrap()).join("OCCT").to_string_lossy()
+    );
+    println!(
+        "cargo:rustc-env=OCCT_PATCH_DIR={}",
+        Path::new(&var("CARGO_MANIFEST_DIR").unwrap()).join("patch").to_string_lossy()
+    );
 }

--- a/crates/occt-sys/src/lib.rs
+++ b/crates/occt-sys/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{
     env::var,
+    fs,
     path::{Path, PathBuf},
 };
 
@@ -18,6 +19,10 @@ pub fn occt_path() -> PathBuf {
 
 /// Build the OCCT library.
 pub fn build_occt() {
+    let _ = fs::create_dir_all(occt_path());
+    let _ = fs::create_dir_all(occt_path().join(LIB_DIR));
+    let _ = fs::create_dir_all(occt_path().join(INCLUDE_DIR));
+
     cmake::Config::new(Path::new(env!("OCCT_SRC_DIR")))
         .define("BUILD_PATCH", Path::new(env!("OCCT_PATCH_DIR")))
         .define("BUILD_LIBRARY_TYPE", "Static")

--- a/crates/occt-sys/src/lib.rs
+++ b/crates/occt-sys/src/lib.rs
@@ -1,6 +1,5 @@
 use std::{
     env::var,
-    fs, io,
     path::{Path, PathBuf},
 };
 
@@ -12,9 +11,9 @@ const INCLUDE_DIR: &str = "include";
 ///
 /// Only valid during build (`cargo clean` removes these files).
 pub fn occt_path() -> PathBuf {
-    // moves the output into target/TARGET/PROFILE/build/OCCT
+    // moves the output into target/TARGET/OCCT
     // this way its less likely to be rebuilt without a cargo clean
-    Path::new(&var("OUT_DIR").expect("missing OUT_DIR")).join("../../OCCT")
+    Path::new(&var("OUT_DIR").expect("missing OUT_DIR")).join("../../../../OCCT")
 }
 
 /// Build the OCCT library.
@@ -41,6 +40,7 @@ pub fn build_occt() {
         .define("USE_XLIB", "FALSE")
         .define("INSTALL_DIR_LIB", LIB_DIR)
         .define("INSTALL_DIR_INCLUDE", INCLUDE_DIR)
+        .profile("Release")
         .out_dir(occt_path())
         .build();
 }

--- a/crates/occt-sys/src/lib.rs
+++ b/crates/occt-sys/src/lib.rs
@@ -1,5 +1,7 @@
-use std::path::{Path, PathBuf};
-use std::env::var;
+use std::{
+    env::var,
+    path::{Path, PathBuf},
+};
 
 const LIB_DIR: &str = "lib";
 const INCLUDE_DIR: &str = "include";

--- a/crates/occt-sys/src/lib.rs
+++ b/crates/occt-sys/src/lib.rs
@@ -50,7 +50,9 @@ pub fn build_occt() {
         .define("INSTALL_DIR_INCLUDE", INCLUDE_DIR)
         .build();
 
-    copy_dir_all(dir, occt_path()).expect("failed to copy files");
+    copy_dir_all(dir.join(LIB_DIR), occt_path().join(LIB_DIR)).expect("failed to copy lib files");
+    copy_dir_all(dir.join(INCLUDE_DIR), occt_path().join(INCLUDE_DIR))
+        .expect("failed to copy include files");
 }
 
 fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {

--- a/crates/occt-sys/src/lib.rs
+++ b/crates/occt-sys/src/lib.rs
@@ -1,9 +1,43 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::env::var;
+
+const LIB_DIR: &str = "lib";
+const INCLUDE_DIR: &str = "include";
 
 /// Get the path to the OCCT library installation directory to be
 /// used in build scripts.
 ///
 /// Only valid during build (`cargo clean` removes these files).
-pub fn occt_path() -> &'static Path {
-    Path::new(env!("OCCT_PATH"))
+pub fn occt_path() -> PathBuf {
+    // moves the output into target/TARGET/PROFILE/build/OCCT
+    // this way its less likely to be rebuilt without a cargo clean
+    Path::new(&var("OUT_DIR").expect("missing OUT_DIR")).join("../../OCCT")
+}
+
+/// Build the OCCT library.
+pub fn build_occt() {
+    cmake::Config::new(Path::new(env!("OCCT_SRC_DIR")))
+        .define("BUILD_PATCH", Path::new(env!("OCCT_PATCH_DIR")))
+        .define("BUILD_LIBRARY_TYPE", "Static")
+        .define("BUILD_MODULE_ApplicationFramework", "FALSE")
+        .define("BUILD_MODULE_Draw", "FALSE")
+        .define("USE_D3D", "FALSE")
+        .define("USE_DRACO", "FALSE")
+        .define("USE_EIGEN", "FALSE")
+        .define("USE_FFMPEG", "FALSE")
+        .define("USE_FREEIMAGE", "FALSE")
+        .define("USE_FREETYPE", "FALSE")
+        .define("USE_GLES2", "FALSE")
+        .define("USE_OPENGL", "FALSE")
+        .define("USE_OPENVR", "FALSE")
+        .define("USE_RAPIDJSON", "FALSE")
+        .define("USE_TBB", "FALSE")
+        .define("USE_TCL", "FALSE")
+        .define("USE_TK", "FALSE")
+        .define("USE_VTK", "FALSE")
+        .define("USE_XLIB", "FALSE")
+        .define("INSTALL_DIR_LIB", LIB_DIR)
+        .define("INSTALL_DIR_INCLUDE", INCLUDE_DIR)
+        .out_dir(occt_path())
+        .build();
 }

--- a/crates/opencascade-sys/Cargo.toml
+++ b/crates/opencascade-sys/Cargo.toml
@@ -13,7 +13,7 @@ cxx = "1"
 [build-dependencies]
 cmake = "0.1"
 cxx-build = "1"
-occt-sys = { version = "0.3", optional = true }
+occt-sys = { path = "../occt-sys", optional = true }
 
 [features]
 builtin = ["occt-sys"]

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -86,6 +86,7 @@ impl OcctConfig {
         // Add path to builtin OCCT
         #[cfg(feature = "builtin")]
         {
+            occt_sys::build_occt();
             std::env::set_var("DEP_OCCT_ROOT", occt_sys::occt_path().as_os_str());
         }
 

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -285,7 +285,7 @@ HandlePoly_Triangulation_ctor(std::unique_ptr<Poly_Triangulation> triangulation)
 }
 
 inline std::unique_ptr<HandlePoly_Triangulation> BRep_Tool_Triangulation(const TopoDS_Face &face,
-                                                                          TopLoc_Location &location) {
+                                                                         TopLoc_Location &location) {
   return std::unique_ptr<HandlePoly_Triangulation>(
       new opencascade::handle<Poly_Triangulation>(BRep_Tool::Triangulation(face, location)));
 }

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -97,8 +97,8 @@ typedef opencascade::handle<Geom2d_Curve> HandleGeom2d_Curve;
 typedef opencascade::handle<Geom2d_Ellipse> HandleGeom2d_Ellipse;
 typedef opencascade::handle<Geom2d_TrimmedCurve> HandleGeom2d_TrimmedCurve;
 typedef opencascade::handle<Geom_CylindricalSurface> HandleGeom_CylindricalSurface;
-typedef opencascade::handle<Poly_Triangulation> Handle_Poly_Triangulation;
-typedef opencascade::handle<TopTools_HSequenceOfShape> Handle_TopTools_HSequenceOfShape;
+typedef opencascade::handle<Poly_Triangulation> HandlePoly_Triangulation;
+typedef opencascade::handle<TopTools_HSequenceOfShape> HandleTopTools_HSequenceOfShape;
 
 // Handle stuff
 template <typename T> const T &handle_try_deref(const opencascade::handle<T> &handle) {
@@ -279,14 +279,14 @@ inline std::unique_ptr<gp_Trsf> TopLoc_Location_Transformation(const TopLoc_Loca
   return std::unique_ptr<gp_Trsf>(new gp_Trsf(location.Transformation()));
 }
 
-inline std::unique_ptr<Handle_Poly_Triangulation>
-Handle_Poly_Triangulation_ctor(std::unique_ptr<Poly_Triangulation> triangulation) {
-  return std::unique_ptr<Handle_Poly_Triangulation>(new Handle_Poly_Triangulation(triangulation.release()));
+inline std::unique_ptr<HandlePoly_Triangulation>
+HandlePoly_Triangulation_ctor(std::unique_ptr<Poly_Triangulation> triangulation) {
+  return std::unique_ptr<HandlePoly_Triangulation>(new HandlePoly_Triangulation(triangulation.release()));
 }
 
-inline std::unique_ptr<Handle_Poly_Triangulation> BRep_Tool_Triangulation(const TopoDS_Face &face,
+inline std::unique_ptr<HandlePoly_Triangulation> BRep_Tool_Triangulation(const TopoDS_Face &face,
                                                                           TopLoc_Location &location) {
-  return std::unique_ptr<Handle_Poly_Triangulation>(
+  return std::unique_ptr<HandlePoly_Triangulation>(
       new opencascade::handle<Poly_Triangulation>(BRep_Tool::Triangulation(face, location)));
 }
 
@@ -434,27 +434,27 @@ inline std::unique_ptr<gp_Pnt2d> TColgp_Array1OfPnt2d_Value(const TColgp_Array1O
   return std::unique_ptr<gp_Pnt2d>(new gp_Pnt2d(array.Value(index)));
 }
 
-inline void connect_edges_to_wires(Handle_TopTools_HSequenceOfShape &edges, const Standard_Real toler,
-                                   const Standard_Boolean shared, Handle_TopTools_HSequenceOfShape &wires) {
+inline void connect_edges_to_wires(HandleTopTools_HSequenceOfShape &edges, const Standard_Real toler,
+                                   const Standard_Boolean shared, HandleTopTools_HSequenceOfShape &wires) {
   ShapeAnalysis_FreeBounds::ConnectEdgesToWires(edges, toler, shared, wires);
 }
 
-inline std::unique_ptr<Handle_TopTools_HSequenceOfShape> new_Handle_TopTools_HSequenceOfShape() {
+inline std::unique_ptr<HandleTopTools_HSequenceOfShape> new_HandleTopTools_HSequenceOfShape() {
   auto sequence = new TopTools_HSequenceOfShape();
   auto handle = new opencascade::handle<TopTools_HSequenceOfShape>(sequence);
 
-  return std::unique_ptr<Handle_TopTools_HSequenceOfShape>(handle);
+  return std::unique_ptr<HandleTopTools_HSequenceOfShape>(handle);
 }
 
-inline void TopTools_HSequenceOfShape_append(Handle_TopTools_HSequenceOfShape &handle, const TopoDS_Shape &shape) {
+inline void TopTools_HSequenceOfShape_append(HandleTopTools_HSequenceOfShape &handle, const TopoDS_Shape &shape) {
   handle->Append(shape);
 }
 
-inline Standard_Integer TopTools_HSequenceOfShape_length(const Handle_TopTools_HSequenceOfShape &handle) {
+inline Standard_Integer TopTools_HSequenceOfShape_length(const HandleTopTools_HSequenceOfShape &handle) {
   return handle->Length();
 }
 
-inline const TopoDS_Shape &TopTools_HSequenceOfShape_value(const Handle_TopTools_HSequenceOfShape &handle,
+inline const TopoDS_Shape &TopTools_HSequenceOfShape_value(const HandleTopTools_HSequenceOfShape &handle,
                                                            Standard_Integer index) {
   return handle->Value(index);
 }

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -85,7 +85,7 @@ pub mod ffi {
         type HandleGeom2d_Ellipse;
         type HandleGeom2d_TrimmedCurve;
         type HandleGeom_CylindricalSurface;
-        type Handle_TopTools_HSequenceOfShape;
+        type HandleTopTools_HSequenceOfShape;
 
         pub fn DynamicType(surface: &HandleGeomSurface) -> &HandleStandardType;
         pub fn type_name(handle: &HandleStandardType) -> String;
@@ -109,7 +109,7 @@ pub mod ffi {
         pub fn IsNull(self: &HandleGeom2d_Ellipse) -> bool;
         pub fn IsNull(self: &HandleGeom2d_TrimmedCurve) -> bool;
         pub fn IsNull(self: &HandleGeom_CylindricalSurface) -> bool;
-        pub fn IsNull(self: &Handle_TopTools_HSequenceOfShape) -> bool;
+        pub fn IsNull(self: &HandleTopTools_HSequenceOfShape) -> bool;
 
         pub fn HandleGeomCurve_Value(curve: &HandleGeomCurve, u: f64) -> UniquePtr<gp_Pnt>;
 
@@ -214,21 +214,21 @@ pub mod ffi {
 
         pub fn Length(self: &TopTools_HSequenceOfShape) -> i32;
 
-        pub fn new_Handle_TopTools_HSequenceOfShape() -> UniquePtr<Handle_TopTools_HSequenceOfShape>;
+        pub fn new_HandleTopTools_HSequenceOfShape() -> UniquePtr<HandleTopTools_HSequenceOfShape>;
         pub fn TopTools_HSequenceOfShape_append(
-            handle: Pin<&mut Handle_TopTools_HSequenceOfShape>,
+            handle: Pin<&mut HandleTopTools_HSequenceOfShape>,
             shape: &TopoDS_Shape,
         );
 
-        pub fn TopTools_HSequenceOfShape_length(handle: &Handle_TopTools_HSequenceOfShape) -> i32;
+        pub fn TopTools_HSequenceOfShape_length(handle: &HandleTopTools_HSequenceOfShape) -> i32;
         pub fn TopTools_HSequenceOfShape_value(
-            handle: &Handle_TopTools_HSequenceOfShape,
+            handle: &HandleTopTools_HSequenceOfShape,
             index: i32,
         ) -> &TopoDS_Shape;
 
         #[cxx_name = "handle_try_deref"]
-        pub fn Handle_TopTools_HSequenceOfShape_Get(
-            handle: &Handle_TopTools_HSequenceOfShape,
+        pub fn HandleTopTools_HSequenceOfShape_Get(
+            handle: &HandleTopTools_HSequenceOfShape,
         ) -> Result<&TopTools_HSequenceOfShape>;
 
         // Geometry
@@ -928,7 +928,7 @@ pub mod ffi {
 
         #[cxx_name = "construct_unique"]
         pub fn BRepBuilderAPI_MakeShapeOnMesh_ctor(
-            mesh: &Handle_Poly_Triangulation,
+            mesh: &HandlePoly_Triangulation,
         ) -> UniquePtr<BRepBuilderAPI_MakeShapeOnMesh>;
 
         pub fn Shape(self: Pin<&mut BRepBuilderAPI_MakeShapeOnMesh>) -> &TopoDS_Shape;
@@ -994,7 +994,7 @@ pub mod ffi {
         pub fn BRep_Tool_Triangulation(
             face: &TopoDS_Face,
             location: Pin<&mut TopLoc_Location>,
-        ) -> UniquePtr<Handle_Poly_Triangulation>;
+        ) -> UniquePtr<HandlePoly_Triangulation>;
 
         type BRepIntCurveSurface_Inter;
 
@@ -1095,16 +1095,16 @@ pub mod ffi {
 
         pub fn TopLoc_Location_Transformation(location: &TopLoc_Location) -> UniquePtr<gp_Trsf>;
 
-        type Handle_Poly_Triangulation;
+        type HandlePoly_Triangulation;
 
-        pub fn Handle_Poly_Triangulation_ctor(
+        pub fn HandlePoly_Triangulation_ctor(
             triangulation: UniquePtr<Poly_Triangulation>,
-        ) -> UniquePtr<Handle_Poly_Triangulation>;
+        ) -> UniquePtr<HandlePoly_Triangulation>;
 
-        pub fn IsNull(self: &Handle_Poly_Triangulation) -> bool;
+        pub fn IsNull(self: &HandlePoly_Triangulation) -> bool;
         #[cxx_name = "handle_try_deref"]
-        pub fn Handle_Poly_Triangulation_Get(
-            handle: &Handle_Poly_Triangulation,
+        pub fn HandlePoly_Triangulation_Get(
+            handle: &HandlePoly_Triangulation,
         ) -> Result<&Poly_Triangulation>;
 
         type Poly_Triangulation;
@@ -1149,10 +1149,10 @@ pub mod ffi {
         type Poly_Connect;
         #[cxx_name = "construct_unique"]
         pub fn Poly_Connect_ctor(
-            triangulation: &Handle_Poly_Triangulation,
+            triangulation: &HandlePoly_Triangulation,
         ) -> UniquePtr<Poly_Connect>;
 
-        pub fn compute_normals(face: &TopoDS_Face, triangulation: &Handle_Poly_Triangulation);
+        pub fn compute_normals(face: &TopoDS_Face, triangulation: &HandlePoly_Triangulation);
 
         // Edge approximation
         type GCPnts_TangentialDeflection;
@@ -1213,10 +1213,10 @@ pub mod ffi {
         pub fn Shape(self: &ShapeUpgrade_UnifySameDomain) -> &TopoDS_Shape;
 
         pub fn connect_edges_to_wires(
-            edges: Pin<&mut Handle_TopTools_HSequenceOfShape>,
+            edges: Pin<&mut HandleTopTools_HSequenceOfShape>,
             tolerance: f64,
             shared: bool,
-            wires: Pin<&mut Handle_TopTools_HSequenceOfShape>,
+            wires: Pin<&mut HandleTopTools_HSequenceOfShape>,
         );
     }
 }

--- a/crates/opencascade-sys/tests/triangulation.rs
+++ b/crates/opencascade-sys/tests/triangulation.rs
@@ -1,6 +1,6 @@
 use opencascade_sys::ffi::{
     new_point, BRepMesh_IncrementalMesh_ctor, BRepPrimAPI_MakeBox_ctor, BRep_Tool_Triangulation,
-    Handle_Poly_Triangulation_Get, Poly_Triangulation_Node, TopAbs_ShapeEnum, TopExp_Explorer_ctor,
+    HandlePoly_Triangulation_Get, Poly_Triangulation_Node, TopAbs_ShapeEnum, TopExp_Explorer_ctor,
     TopLoc_Location_ctor, TopoDS_cast_to_face,
 };
 
@@ -20,7 +20,7 @@ fn it_can_access_mesh_triangulation() {
         let mut location = TopLoc_Location_ctor();
 
         let triangulation_handle = BRep_Tool_Triangulation(face, location.pin_mut());
-        if let Ok(triangulation) = Handle_Poly_Triangulation_Get(&triangulation_handle) {
+        if let Ok(triangulation) = HandlePoly_Triangulation_Get(&triangulation_handle) {
             for index in 0..triangulation.NbTriangles() {
                 let triangle = triangulation.Triangle(index + 1);
 

--- a/crates/opencascade/src/mesh.rs
+++ b/crates/opencascade/src/mesh.rs
@@ -43,7 +43,7 @@ impl Mesher {
             let triangulation_handle =
                 ffi::BRep_Tool_Triangulation(&face.inner, location.pin_mut());
 
-            let triangulation = ffi::Handle_Poly_Triangulation_Get(&triangulation_handle)
+            let triangulation = ffi::HandlePoly_Triangulation_Get(&triangulation_handle)
                 .map_err(|_| Error::UntriangulatedFace)?;
 
             let index_offset = vertices.len();

--- a/crates/opencascade/src/primitives/wire.rs
+++ b/crates/opencascade/src/primitives/wire.rs
@@ -83,14 +83,14 @@ impl Wire {
         unordered_edges: impl IntoIterator<Item = T>,
         edge_connection: EdgeConnection,
     ) -> Self {
-        let mut edges = ffi::new_Handle_TopTools_HSequenceOfShape();
+        let mut edges = ffi::new_HandleTopTools_HSequenceOfShape();
 
         for edge in unordered_edges {
             let edge_shape = ffi::cast_edge_to_shape(&edge.as_ref().inner);
             ffi::TopTools_HSequenceOfShape_append(edges.pin_mut(), edge_shape);
         }
 
-        let mut wires = ffi::new_Handle_TopTools_HSequenceOfShape();
+        let mut wires = ffi::new_HandleTopTools_HSequenceOfShape();
 
         let (tolerance, shared) = match edge_connection {
             EdgeConnection::Exact => (0.0, true),


### PR DESCRIPTION
Fix for https://github.com/bschwind/opencascade-rs/issues/160

`occt-sys` no longer builds OCCT in the build.rs file. This allows it to be re-included in the workspace and the build still only triggered when the `builtin` feature is enabled. 

This also now passes the correct ENV variables to the build so it is built for TARGET and not HOST. 

Finally added CI to test these builds work on various platforms. 

Had to rename `Handle_*` to `Handle*` for MSVC.