### PR TITLE
Add copy mingw runtime to the output directory

### DIFF
--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -158,10 +158,7 @@ impl OcctConfig {
 }
 
 fn find_mingw_dll(file: &str) -> Vec<String> {
-    let output = std::process::Command::new("find")
-        .args(["/usr", "-name", file])
-        .output()
-        .unwrap();
+    let output = std::process::Command::new("find").args(["/usr", "-name", file]).output().unwrap();
     String::from_utf8_lossy(&output.stdout)
         .split('\n')
         .map(|path| path.to_string())

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -54,24 +54,18 @@ fn main() {
         let out_dir = std::env::var("OUT_DIR").expect("No OUT_DIR environment variable defined");
         let out_dir = std::path::Path::new(&out_dir).join("../../..");
         let mut dll_paths = vec![];
-        for dll in [
-            "libgcc_s_seh-1.dll",
-            "libstdc++-6.dll",
-            "libwinpthread-1.dll",
-        ] {
+        for dll in ["libgcc_s_seh-1.dll", "libstdc++-6.dll", "libwinpthread-1.dll"] {
             for path in find_mingw_dll(dll) {
                 dll_paths.push(path);
             }
         }
-        let dll_paths = dll_paths
-            .into_iter()
-            .filter(|path| path.contains("x86_64"))
-            .collect::<Vec<_>>();
+        let dll_paths =
+            dll_paths.into_iter().filter(|path| path.contains("x86_64")).collect::<Vec<_>>();
         for dll in dll_paths {
             let path = std::path::Path::new(&dll);
             let name = path.file_name().unwrap().to_str().unwrap();
             if !out_dir.join(name).exists() {
-                std::fs::copy(&path, out_dir.join(name)).unwrap();
+                std::fs::copy(path, out_dir.join(name)).unwrap();
             }
         }
     }
@@ -169,7 +163,7 @@ fn find_mingw_dll(file: &str) -> Vec<String> {
         .output()
         .expect("No install mingw-w64.");
     String::from_utf8_lossy(&output.stdout)
-        .split("\n")
+        .split('\n')
         .map(|path| path.to_string())
         .collect::<Vec<_>>()
 }

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -161,7 +161,7 @@ fn find_mingw_dll(file: &str) -> Vec<String> {
     let output = std::process::Command::new("find")
         .args(["/usr", "-name", file])
         .output()
-        .expect("No install mingw-w64.");
+        .unwrap();
     String::from_utf8_lossy(&output.stdout)
         .split('\n')
         .map(|path| path.to_string())


### PR DESCRIPTION
The binary generated from cross-compiling from linux to windows-gnu cannot run because it lacks the [mingw runtime](https://stackoverflow.com/questions/46728353/mingw-w64-whats-the-purpose-of-libgcc-s-seh-dll) (mingw-w64 under the linux platform).

So I improved this build script so that it copies mingw's runtime to the output directory. In this way, we distribute binaries and these dynamic link libraries, and users do not need the mingw environment.

![mingw-dll](https://github.com/bschwind/opencascade-rs/assets/66518156/b65861b7-f46f-4f07-a8a2-dbbda8013d54)

But we need to wait for #163, the current occt cross-compiled product is still host, not target.