### PR TITLE
Keyboard Case V2

### DIFF
--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -48,6 +48,7 @@ const PCB_BOTTOM_Z: f64 = PCB_TOP_Z - PCB_THICKNESS;
 const PCB_LEFT: f64 = ORIGIN.x - PCB_DIMENSION_TOLERANCE;
 const PCB_LEFT_NO_TOLERANCE: f64 = ORIGIN.x;
 const PCB_RIGHT: f64 = PCB_LEFT_NO_TOLERANCE + PCB_WIDTH + PCB_DIMENSION_TOLERANCE;
+const PCB_RIGHT_NO_TOLERANCE: f64 = PCB_LEFT_NO_TOLERANCE + PCB_WIDTH;
 
 // Top Plate
 const TOP_PLATE_BOTTOM_Z: f64 = 3.4;
@@ -133,6 +134,14 @@ const SUPPORT_POSTS: &[SupportPost] = &[
     SupportPost {
         pos: DVec2::new(204.75, PCB_TOP_NO_TOLERANCE - SUPPORT_POST_DIST_FROM_EDGE),
         direction: PostDirection::Up,
+    },
+    SupportPost {
+        pos: DVec2::new(PCB_LEFT_NO_TOLERANCE + SUPPORT_POST_DIST_FROM_EDGE, -57.15),
+        direction: PostDirection::Left,
+    },
+    SupportPost {
+        pos: DVec2::new(PCB_RIGHT_NO_TOLERANCE - SUPPORT_POST_DIST_FROM_EDGE, -57.15),
+        direction: PostDirection::Right,
     },
     SupportPost {
         pos: DVec2::new(80.95, PCB_BOTTOM_NO_TOLERANCE + SUPPORT_POST_DIST_FROM_EDGE),

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -36,7 +36,7 @@ const CASE_RIGHT: f64 = PCB_RIGHT + CASE_WALL_THICKNESS;
 const CASE_FLOOR_Z: f64 = PCB_BOTTOM_Z - PCB_SHELF_HEIGHT;
 const CASE_BOTTOM_Z: f64 = CASE_FLOOR_Z - CASE_WALL_THICKNESS;
 
-const CASE_FOOT_THICKNESS: f64 = 2.1;
+const CASE_FOOT_THICKNESS: f64 = 2.0;
 
 // PCB
 const PCB_TOP: f64 = ORIGIN.y + PCB_DIMENSION_TOLERANCE;
@@ -346,7 +346,7 @@ fn case_feet(foot_thickness: f64, z_extrude: f64) -> Shape {
     // A center point "origin" for the feet locations.
     // TODO(bschwind) - Add comments or const values for these magic numbers.
     let reference_point = dvec2(PCB_WIDTH / 2.0, ((CASE_BOTTOM - CASE_TOP) / 2.0) + 0.8 + 5.0);
-    let upper_left_foot_pos = reference_point + dvec2(-90.0, 18.5 + KEY_ROW_VERTICAL_PITCH + 0.1);
+    let upper_left_foot_pos = reference_point + dvec2(-90.0, 18.5 + KEY_ROW_VERTICAL_PITCH + 0.2);
     let bottom_left_foot_pos = upper_left_foot_pos + dvec2(14.0, -(55.3 + KEY_ROW_VERTICAL_PITCH));
 
     let upper_left_foot =
@@ -455,7 +455,7 @@ pub fn shape() -> Shape {
 
     let foot_z_extrude = 2.5;
     let feet_indentation = case_feet(CASE_FOOT_THICKNESS + 0.15, foot_z_extrude);
-    let feet = case_feet(CASE_FOOT_THICKNESS, -foot_z_extrude);
+    let feet = case_feet(CASE_FOOT_THICKNESS, -foot_z_extrude * 2.0);
 
     let case = case.subtract(&feet_indentation).into_shape();
     // let case = case.union(&feet).into_shape();

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -344,17 +344,17 @@ pub fn shape() -> Shape {
     }
 
     // For exporting to smaller 3D printers
-    let corner_1 = DVec3::new(CASE_LEFT, CASE_BOTTOM, CASE_BOTTOM_Z);
-    let corner_2 = DVec3::new(CASE_RIGHT / 2.0, CASE_TOP, CASE_TOP_Z);
-    let left_half = Shape::box_from_corners(corner_1, corner_2);
+    // let corner_1 = DVec3::new(CASE_LEFT, CASE_BOTTOM, CASE_BOTTOM_Z);
+    // let corner_2 = DVec3::new(CASE_RIGHT / 2.0, CASE_TOP, CASE_TOP_Z);
+    // let left_half = Shape::box_from_corners(corner_1, corner_2);
 
     // let corner_1 = DVec3::new(CASE_RIGHT / 2.0, CASE_BOTTOM, CASE_BOTTOM_Z);
     // let corner_2 = DVec3::new(CASE_RIGHT, CASE_TOP, CASE_TOP_Z);
     // let right_half = Shape::box_from_corners(corner_1, corner_2);
 
-    let shape = shape.intersect(&left_half);
+    // let shape = shape.intersect(&left_half);
 
-    shape.write_stl("lol.stl").unwrap();
+    // shape.write_stl("keyboard_half.stl").unwrap();
 
-    shape.into()
+    shape
 }

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -221,7 +221,8 @@ fn case_inner_box() -> Shape {
         .close()
         .fillet(PCB_FILLET_RADIUS)
         .to_face()
-        .extrude(dvec3(0.0, 0.0, CASE_TOP_Z - CASE_FLOOR_Z))
+        // 0.1 is a fudge factor to retrieve edges from boolean subtraction
+        .extrude(dvec3(0.0, 0.0, CASE_TOP_Z + 0.1 - CASE_FLOOR_Z))
         .into_shape()
 }
 
@@ -306,6 +307,7 @@ pub fn shape() -> Shape {
 
     let shape = case_outer_box()
         .subtract(&inner_box)
+        .fillet_new_edges(0.3)
         .union(&top_shelf)
         .union(&bottom_shelf)
         .subtract(&usb_cutout);

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -16,7 +16,7 @@ const TOP_PLATE_THICKNESS: f64 = 1.6;
 const PCB_FILLET_RADIUS: f64 = 2.4;
 
 // "Inflate" the PCB dimensions by this much to create an easier fit.
-const PCB_DIMENSION_TOLERANCE: f64 = 0.0;
+const PCB_DIMENSION_TOLERANCE: f64 = 0.1;
 
 // The origin point for this board is the top left corner
 // of the PCB, on the top surface. The PCB rests on this

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -16,7 +16,7 @@ const TOP_PLATE_THICKNESS: f64 = 1.6;
 const PCB_FILLET_RADIUS: f64 = 2.4;
 
 // "Inflate" the PCB dimensions by this much to create an easier fit.
-const PCB_DIMENSION_TOLERANCE: f64 = 0.9;
+const PCB_DIMENSION_TOLERANCE: f64 = 0.2;
 
 // The origin point for this board is the top left corner
 // of the PCB, on the top surface. The PCB rests on this
@@ -48,7 +48,6 @@ const PCB_BOTTOM_Z: f64 = PCB_TOP_Z - PCB_THICKNESS;
 const PCB_LEFT: f64 = ORIGIN.x - PCB_DIMENSION_TOLERANCE;
 const PCB_LEFT_NO_TOLERANCE: f64 = ORIGIN.x;
 const PCB_RIGHT: f64 = PCB_LEFT_NO_TOLERANCE + PCB_WIDTH + PCB_DIMENSION_TOLERANCE;
-const PCB_RIGHT_NO_TOLERANCE: f64 = PCB_LEFT_NO_TOLERANCE + PCB_WIDTH;
 
 // Top Plate
 const TOP_PLATE_BOTTOM_Z: f64 = 3.4;

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -346,8 +346,9 @@ fn case_feet(foot_thickness: f64, z_extrude: f64) -> Shape {
     // A center point "origin" for the feet locations.
     // TODO(bschwind) - Add comments or const values for these magic numbers.
     let reference_point = dvec2(PCB_WIDTH / 2.0, ((CASE_BOTTOM - CASE_TOP) / 2.0) + 0.8 + 5.0);
-    let upper_left_foot_pos = reference_point + dvec2(-90.0, 18.5 + KEY_ROW_VERTICAL_PITCH + 0.2);
-    let bottom_left_foot_pos = upper_left_foot_pos + dvec2(14.0, -(55.3 + KEY_ROW_VERTICAL_PITCH));
+    let upper_left_foot_pos = reference_point + dvec2(-90.0, 18.5 + KEY_ROW_VERTICAL_PITCH);
+    let bottom_left_foot_pos =
+        upper_left_foot_pos + dvec2(14.0, -(55.3 + KEY_ROW_VERTICAL_PITCH + 0.1));
 
     let upper_left_foot =
         case_foot(upper_left_foot_pos, FootStyle::Line, foot_thickness, z_extrude);

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -16,7 +16,7 @@ const TOP_PLATE_THICKNESS: f64 = 1.6;
 const PCB_FILLET_RADIUS: f64 = 2.4;
 
 // "Inflate" the PCB dimensions by this much to create an easier fit.
-const PCB_DIMENSION_TOLERANCE: f64 = 0.1;
+const PCB_DIMENSION_TOLERANCE: f64 = 0.3;
 
 // The origin point for this board is the top left corner
 // of the PCB, on the top surface. The PCB rests on this
@@ -54,7 +54,7 @@ const PCB_SHELF_THICKNESS_BOTTOM: f64 = 4.0;
 const PCB_SHELF_HEIGHT: f64 = 4.0;
 
 // Top plate support post locations
-const SUPPORT_POST_RADIUS: f64 = 2.25;
+const SUPPORT_POST_RADIUS: f64 = 2.0;
 
 // http://www.metrication.com/engineering/threads.html
 const SUPPORT_POST_DRILL_RADIUS: f64 = 0.8;
@@ -300,7 +300,7 @@ fn pcb_usb_overhang() -> Shape {
 }
 
 fn case_foot(center: DVec2, pointing_down: bool) -> Shape {
-    const FOOT_THICKNESS: f64 = 2.3;
+    const FOOT_THICKNESS: f64 = 2.2;
     const HALF_FOOT_THICKNESS: f64 = FOOT_THICKNESS / 2.0;
     const FOOT_EXTENT: f64 = 15.0;
 

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -16,7 +16,7 @@ const TOP_PLATE_THICKNESS: f64 = 1.6;
 const PCB_FILLET_RADIUS: f64 = 2.4;
 
 // "Inflate" the PCB dimensions by this much to create an easier fit.
-const PCB_DIMENSION_TOLERANCE: f64 = 0.3;
+const PCB_DIMENSION_TOLERANCE: f64 = 0.5;
 
 // The origin point for this board is the top left corner
 // of the PCB, on the top surface. The PCB rests on this

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -333,7 +333,8 @@ fn case_foot(center: DVec2, pointing_down: bool) -> Shape {
             .close()
     };
 
-    sketch.fillet(0.7).to_face().extrude(dvec3(0.0, 0.0, -5.0)).into()
+    // A macbook keycap is about 1mm tall, so give it about 1.5mm of extra clearance.
+    sketch.fillet(0.7).to_face().extrude(dvec3(0.0, 0.0, -2.5)).into()
 }
 
 fn case_feet() -> Shape {

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -1,4 +1,4 @@
-use glam::{dvec3, DVec2, DVec3};
+use glam::{dvec2, dvec3, DVec2, DVec3};
 use opencascade::{
     primitives::{Direction, IntoShape, Shape, Solid},
     workplane::Workplane,
@@ -299,6 +299,28 @@ fn pcb_usb_overhang() -> Shape {
     .into()
 }
 
+fn case_foot(center: DVec2) -> Shape {
+    const FOOT_THICKNESS: f64 = 2.4;
+    const HALF_FOOT_THICKNESS: f64 = FOOT_THICKNESS / 2.0;
+    const FOOT_EXTENT: f64 = 15.0;
+
+    Workplane::xy()
+        .sketch()
+        .move_to(center.x - HALF_FOOT_THICKNESS, center.y - HALF_FOOT_THICKNESS)
+        .line_dx(-FOOT_EXTENT)
+        .line_dy(FOOT_THICKNESS)
+        .line_dx(FOOT_EXTENT * 2.0 + FOOT_THICKNESS)
+        .line_dy(-FOOT_THICKNESS)
+        .line_dx(-FOOT_EXTENT)
+        .line_dy(-FOOT_EXTENT)
+        .line_dx(-FOOT_THICKNESS)
+        .close()
+        .fillet(0.7)
+        .to_face()
+        .extrude(dvec3(0.0, 0.0, 5.0))
+        .into()
+}
+
 pub fn shape() -> Shape {
     let inner_box = case_inner_box();
     let top_shelf = pcb_top_shelf();
@@ -356,5 +378,11 @@ pub fn shape() -> Shape {
 
     // shape.write_stl("keyboard_half.stl").unwrap();
 
-    case
+    // case.write_step("keyboard.step").unwrap();
+
+    // case
+    let foot = case_foot(dvec2(0.0, 0.0));
+    foot.write_step("keyboard_case_foot.step").unwrap();
+
+    foot
 }

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -16,7 +16,7 @@ const TOP_PLATE_THICKNESS: f64 = 1.6;
 const PCB_FILLET_RADIUS: f64 = 2.4;
 
 // "Inflate" the PCB dimensions by this much to create an easier fit.
-const PCB_DIMENSION_TOLERANCE: f64 = 0.5;
+const PCB_DIMENSION_TOLERANCE: f64 = 0.8;
 
 // The origin point for this board is the top left corner
 // of the PCB, on the top surface. The PCB rests on this
@@ -164,14 +164,15 @@ const FEET_CUTOUTS: &[DVec2] = &[
 ];
 
 // USB C Connector Cutout
-const USB_CUTOUT_PADDING: f64 = 0.1;
-const USB_WIDTH: f64 = 9.0;
+const USB_CONNECTOR_PADDING: f64 = 1.0;
+const USB_WIDTH: f64 = 9.0 + USB_CONNECTOR_PADDING;
 const USB_HEIGHT: f64 = 7.45;
-const USB_DEPTH: f64 = 3.26;
+const USB_DEPTH: f64 = 3.26 + USB_CONNECTOR_PADDING;
 const USB_RADIUS: f64 = 1.43;
 
-const USB_LEFT: f64 = 21.724;
-const USB_RIGHT: f64 = USB_LEFT + USB_WIDTH;
+const USB_MIDDLE_X: f64 = 26.194;
+const USB_LEFT: f64 = USB_MIDDLE_X - (USB_WIDTH / 2.0);
+const USB_RIGHT: f64 = USB_MIDDLE_X + (USB_WIDTH / 2.0);
 const USB_TOP: f64 = 3.04;
 const USB_BOTTOM: f64 = USB_TOP - USB_HEIGHT;
 
@@ -257,18 +258,9 @@ fn pcb_bottom_shelf() -> Shape {
 }
 
 fn usb_connector_cutout() -> Shape {
-    let corner_1 = DVec3::new(USB_LEFT - USB_CUTOUT_PADDING, 2.3, PCB_BOTTOM_Z - (USB_DEPTH / 2.0));
-    let corner_2 = DVec3::new(
-        USB_RIGHT + USB_CUTOUT_PADDING,
-        USB_BOTTOM - USB_CUTOUT_PADDING,
-        PCB_BOTTOM_Z + USB_CUTOUT_PADDING,
-    );
-
-    let squared_shape = Shape::box_from_corners(corner_1, corner_2);
-
     let mut usb_workplane = Workplane::xz();
     usb_workplane.set_translation(dvec3(
-        USB_LEFT + (USB_WIDTH / 2.0),
+        USB_MIDDLE_X,
         USB_BOTTOM,
         PCB_BOTTOM_Z - (USB_DEPTH / 2.0),
     ));
@@ -278,13 +270,13 @@ fn usb_connector_cutout() -> Shape {
         .to_face()
         .extrude(dvec3(0.0, USB_HEIGHT + CASE_WALL_THICKNESS, 0.0))
         .into_shape()
-        .union(&squared_shape)
-        .into()
 }
 
 // This is the little trapezoidal PCB shape which helps the USB C connector
 // extend forward into the case.
 fn pcb_usb_overhang() -> Shape {
+    const VERTICAL_PADDING: f64 = 1.0;
+
     let start = CASE_FLOOR_Z;
     Solid::extrude_polygon(
         [
@@ -295,7 +287,7 @@ fn pcb_usb_overhang() -> Shape {
             DVec3::new(33.337, PCB_TOP - PCB_SHELF_THICKNESS_TOP, start),
             DVec3::new(19.05, PCB_TOP - PCB_SHELF_THICKNESS_TOP, start),
         ],
-        PCB_TOP_Z - start,
+        PCB_TOP_Z - start + VERTICAL_PADDING,
     )
     .unwrap()
     .into()

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -40,11 +40,14 @@ const CASE_FOOT_THICKNESS: f64 = 2.2;
 
 // PCB
 const PCB_TOP: f64 = ORIGIN.y + PCB_DIMENSION_TOLERANCE;
+const PCB_TOP_NO_TOLERANCE: f64 = ORIGIN.y;
 const PCB_TOP_Z: f64 = ORIGIN.z;
-const PCB_BOTTOM: f64 = PCB_TOP - PCB_HEIGHT - PCB_DIMENSION_TOLERANCE;
+const PCB_BOTTOM: f64 = PCB_TOP_NO_TOLERANCE - PCB_HEIGHT - PCB_DIMENSION_TOLERANCE;
+const PCB_BOTTOM_NO_TOLERANCE: f64 = PCB_TOP_NO_TOLERANCE - PCB_HEIGHT;
 const PCB_BOTTOM_Z: f64 = PCB_TOP_Z - PCB_THICKNESS;
 const PCB_LEFT: f64 = ORIGIN.x - PCB_DIMENSION_TOLERANCE;
-const PCB_RIGHT: f64 = PCB_LEFT + PCB_WIDTH + PCB_DIMENSION_TOLERANCE;
+const PCB_LEFT_NO_TOLERANCE: f64 = ORIGIN.x;
+const PCB_RIGHT: f64 = PCB_LEFT_NO_TOLERANCE + PCB_WIDTH + PCB_DIMENSION_TOLERANCE;
 
 // Top Plate
 const TOP_PLATE_BOTTOM_Z: f64 = 3.4;
@@ -60,7 +63,7 @@ const SUPPORT_POST_RADIUS: f64 = 2.0;
 
 // http://www.metrication.com/engineering/threads.html
 const SUPPORT_POST_DRILL_RADIUS: f64 = 0.8;
-const SUPPORT_POST_DIST_FROM_EDGE: f64 = 2.5;
+const SUPPORT_POST_DIST_FROM_EDGE: f64 = 2.5 + PCB_DIMENSION_TOLERANCE;
 
 #[allow(unused)]
 enum PostDirection {
@@ -85,44 +88,34 @@ impl SupportPost {
         let m2_drill_hole =
             Shape::cylinder(pos, SUPPORT_POST_DRILL_RADIUS, DVec3::Z, top_z - bottom_z);
 
+        let dist_from_edge = SUPPORT_POST_DIST_FROM_EDGE + PCB_DIMENSION_TOLERANCE;
+
         let box_part = match self.direction {
             PostDirection::Up => {
-                let corner_1 = DVec3::new(
-                    pos.x - SUPPORT_POST_RADIUS,
-                    pos.y + SUPPORT_POST_DIST_FROM_EDGE,
-                    bottom_z,
-                );
+                let corner_1 =
+                    DVec3::new(pos.x - SUPPORT_POST_RADIUS, pos.y + dist_from_edge, bottom_z);
                 let corner_2 = DVec3::new(pos.x + SUPPORT_POST_RADIUS, pos.y, top_z);
 
                 Shape::box_from_corners(corner_1, corner_2)
             },
             PostDirection::Down => {
                 let corner_1 = DVec3::new(pos.x - SUPPORT_POST_RADIUS, pos.y, bottom_z);
-                let corner_2 = DVec3::new(
-                    pos.x + SUPPORT_POST_RADIUS,
-                    pos.y - SUPPORT_POST_DIST_FROM_EDGE,
-                    top_z,
-                );
+                let corner_2 =
+                    DVec3::new(pos.x + SUPPORT_POST_RADIUS, pos.y - dist_from_edge, top_z);
 
                 Shape::box_from_corners(corner_1, corner_2)
             },
             PostDirection::Left => {
-                let corner_1 = DVec3::new(
-                    pos.x - SUPPORT_POST_DIST_FROM_EDGE,
-                    pos.y - SUPPORT_POST_RADIUS,
-                    bottom_z,
-                );
+                let corner_1 =
+                    DVec3::new(pos.x - dist_from_edge, pos.y - SUPPORT_POST_RADIUS, bottom_z);
                 let corner_2 = DVec3::new(pos.x, pos.y + SUPPORT_POST_RADIUS, top_z);
 
                 Shape::box_from_corners(corner_1, corner_2)
             },
             PostDirection::Right => {
                 let corner_1 = DVec3::new(pos.x, pos.y - SUPPORT_POST_RADIUS, bottom_z);
-                let corner_2 = DVec3::new(
-                    pos.x + SUPPORT_POST_DIST_FROM_EDGE,
-                    pos.y + SUPPORT_POST_RADIUS,
-                    top_z,
-                );
+                let corner_2 =
+                    DVec3::new(pos.x + dist_from_edge, pos.y + SUPPORT_POST_RADIUS, top_z);
 
                 Shape::box_from_corners(corner_1, corner_2)
             },
@@ -134,19 +127,19 @@ impl SupportPost {
 
 const SUPPORT_POSTS: &[SupportPost] = &[
     SupportPost {
-        pos: DVec2::new(119.075, PCB_TOP - SUPPORT_POST_DIST_FROM_EDGE),
+        pos: DVec2::new(119.075, PCB_TOP_NO_TOLERANCE - SUPPORT_POST_DIST_FROM_EDGE),
         direction: PostDirection::Up,
     },
     SupportPost {
-        pos: DVec2::new(204.75, PCB_TOP - SUPPORT_POST_DIST_FROM_EDGE),
+        pos: DVec2::new(204.75, PCB_TOP_NO_TOLERANCE - SUPPORT_POST_DIST_FROM_EDGE),
         direction: PostDirection::Up,
     },
     SupportPost {
-        pos: DVec2::new(80.95, PCB_BOTTOM + SUPPORT_POST_DIST_FROM_EDGE),
+        pos: DVec2::new(80.95, PCB_BOTTOM_NO_TOLERANCE + SUPPORT_POST_DIST_FROM_EDGE),
         direction: PostDirection::Down,
     },
     SupportPost {
-        pos: DVec2::new(200.05, PCB_BOTTOM + SUPPORT_POST_DIST_FROM_EDGE),
+        pos: DVec2::new(200.05, PCB_BOTTOM_NO_TOLERANCE + SUPPORT_POST_DIST_FROM_EDGE),
         direction: PostDirection::Down,
     },
 ];

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -25,7 +25,7 @@ const PCB_DIMENSION_TOLERANCE: f64 = 0.0;
 const ORIGIN: DVec3 = DVec3::new(0.0, 0.0, 0.0);
 
 // Case
-const CASE_WALL_THICKNESS: f64 = 3.0;
+const CASE_WALL_THICKNESS: f64 = 3.5;
 const CASE_LIP_HEIGHT: f64 = 1.0;
 
 const CASE_TOP: f64 = PCB_TOP + CASE_WALL_THICKNESS;
@@ -334,7 +334,7 @@ pub fn shape() -> Shape {
         .filter(|e| e.start_point().y > 0.0) // Only chamfer edges on the exterior of the case
         .collect();
 
-    let shape = shape.chamfer_edges(0.5, new_edges);
+    let shape = shape.chamfer_edges(1.0, new_edges);
 
     let mut shape = shape.into_shape();
     // .chamfer_new_edges(0.5)
@@ -363,17 +363,17 @@ pub fn shape() -> Shape {
     }
 
     // For exporting to smaller 3D printers
-    // let corner_1 = DVec3::new(CASE_LEFT, CASE_BOTTOM, CASE_BOTTOM_Z);
-    // let corner_2 = DVec3::new(CASE_RIGHT / 2.0, CASE_TOP, CASE_TOP_Z);
-    // let left_half = Shape::box_from_corners(corner_1, corner_2);
+    let corner_1 = DVec3::new(CASE_LEFT, CASE_BOTTOM, CASE_BOTTOM_Z);
+    let corner_2 = DVec3::new(CASE_RIGHT / 2.0, CASE_TOP, CASE_TOP_Z);
+    let left_half = Shape::box_from_corners(corner_1, corner_2);
 
     // let corner_1 = DVec3::new(CASE_RIGHT / 2.0, CASE_BOTTOM, CASE_BOTTOM_Z);
     // let corner_2 = DVec3::new(CASE_RIGHT, CASE_TOP, CASE_TOP_Z);
     // let right_half = Shape::box_from_corners(corner_1, corner_2);
 
-    // outer_box.intersect(&right_half);
+    let shape = shape.intersect(&left_half);
 
     shape.write_stl("lol.stl").unwrap();
 
-    shape
+    shape.into()
 }

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -354,6 +354,24 @@ fn case_feet() -> Shape {
         .into()
 }
 
+const PUSH_SLOT_LOCATIONS: &[DVec2] = &[
+    DVec2::new(PCB_LEFT + 58.0, PCB_BOTTOM + 8.0),
+    DVec2::new(PCB_RIGHT - 58.0, PCB_BOTTOM + 8.0),
+];
+
+// A slot to help remove the PCB by pushing through the bottom of the case.
+fn push_slot(center: DVec2) -> Shape {
+    let mut cutout_workplane = Workplane::xy();
+    cutout_workplane.set_translation(dvec3(center.x, center.y, CASE_FLOOR_Z));
+
+    cutout_workplane
+        .rect(10.0, 3.0)
+        .fillet(1.0)
+        .to_face()
+        .extrude(dvec3(0.0, 0.0, -CASE_WALL_THICKNESS))
+        .into()
+}
+
 pub fn shape() -> Shape {
     let inner_box = case_inner_box();
     let top_shelf = pcb_top_shelf();
@@ -396,6 +414,11 @@ pub fn shape() -> Shape {
         let dir = DVec3::new(0.0, 0.0, -1.0);
 
         case = case.drill_hole(pos, dir, PINHOLE_BUTTON_RADIUS);
+    }
+
+    for slot_center in PUSH_SLOT_LOCATIONS {
+        let slot = push_slot(*slot_center);
+        case = case.subtract(&slot).into();
     }
 
     // For exporting to smaller 3D printers

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -136,14 +136,6 @@ const SUPPORT_POSTS: &[SupportPost] = &[
         direction: PostDirection::Up,
     },
     SupportPost {
-        pos: DVec2::new(PCB_LEFT_NO_TOLERANCE + SUPPORT_POST_DIST_FROM_EDGE, -57.15),
-        direction: PostDirection::Left,
-    },
-    SupportPost {
-        pos: DVec2::new(PCB_RIGHT_NO_TOLERANCE - SUPPORT_POST_DIST_FROM_EDGE, -57.15),
-        direction: PostDirection::Right,
-    },
-    SupportPost {
         pos: DVec2::new(80.95, PCB_BOTTOM_NO_TOLERANCE + SUPPORT_POST_DIST_FROM_EDGE),
         direction: PostDirection::Down,
     },

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -398,12 +398,12 @@ pub fn shape() -> Shape {
     let pcb_center = dvec2(PCB_WIDTH / 2.0, PCB_HEIGHT / 2.0);
 
     let upper_left_foot_pos = pcb_center + dvec2(-90.0, 18.5);
-    let bottom_left_foot_pos = upper_left_foot_pos + dvec2(14.0, -54.7);
+    let bottom_left_foot_pos = upper_left_foot_pos + dvec2(14.0, -55.3);
 
     let upper_left_foot = case_foot(upper_left_foot_pos, true);
-    let upper_right_foot = case_foot(upper_left_foot_pos + dvec2(170.46, 0.0), true);
+    let upper_right_foot = case_foot(upper_left_foot_pos + dvec2(171.1, 0.0), true);
     let bottom_left_foot = case_foot(bottom_left_foot_pos, false);
-    let bottom_right_foot = case_foot(bottom_left_foot_pos + dvec2(151.52, 0.0), false);
+    let bottom_right_foot = case_foot(bottom_left_foot_pos + dvec2(152.1, 0.0), false);
 
     // Temporary plate to hold the feet
     let corner_1 = DVec3::new(pcb_center.x - 120.0, pcb_center.y - 35.0 - 10.0, 0.0);

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -304,8 +304,11 @@ fn case_foot(center: DVec2, pointing_down: bool) -> Shape {
     const HALF_FOOT_THICKNESS: f64 = FOOT_THICKNESS / 2.0;
     const FOOT_EXTENT: f64 = 15.0;
 
+    let mut workplane = Workplane::xy();
+    workplane.set_translation(dvec3(0.0, 0.0, CASE_BOTTOM_Z));
+
     let sketch = if pointing_down {
-        Workplane::xy()
+        workplane
             .sketch()
             .move_to(center.x - HALF_FOOT_THICKNESS, center.y - HALF_FOOT_THICKNESS)
             .line_dx(-FOOT_EXTENT)
@@ -317,7 +320,7 @@ fn case_foot(center: DVec2, pointing_down: bool) -> Shape {
             .line_dx(-FOOT_THICKNESS)
             .close()
     } else {
-        Workplane::xy()
+        workplane
             .sketch()
             .move_to(center.x + HALF_FOOT_THICKNESS, center.y + HALF_FOOT_THICKNESS)
             .line_dx(FOOT_EXTENT)
@@ -331,6 +334,23 @@ fn case_foot(center: DVec2, pointing_down: bool) -> Shape {
     };
 
     sketch.fillet(0.7).to_face().extrude(dvec3(0.0, 0.0, -5.0)).into()
+}
+
+fn case_feet() -> Shape {
+    let reference_point = dvec2(PCB_WIDTH / 2.0, ((CASE_BOTTOM - CASE_TOP) / 2.0) + 0.8);
+    let upper_left_foot_pos = reference_point + dvec2(-90.0, 18.5);
+    let bottom_left_foot_pos = upper_left_foot_pos + dvec2(14.0, -55.3);
+
+    let upper_left_foot = case_foot(upper_left_foot_pos, true);
+    let upper_right_foot = case_foot(upper_left_foot_pos + dvec2(171.1, 0.0), true);
+    let bottom_left_foot = case_foot(bottom_left_foot_pos, false);
+    let bottom_right_foot = case_foot(bottom_left_foot_pos + dvec2(152.1, 0.0), false);
+
+    upper_left_foot
+        .union(&upper_right_foot)
+        .union(&bottom_left_foot)
+        .union(&bottom_right_foot)
+        .into()
 }
 
 pub fn shape() -> Shape {
@@ -390,34 +410,11 @@ pub fn shape() -> Shape {
 
     // shape.write_stl("keyboard_half.stl").unwrap();
 
-    // case.write_step("keyboard.step").unwrap();
+    let feet = case_feet();
 
-    // case
-    // let foot = case_foot(dvec2(0.0, 0.0), pointing_down);
+    let case = case.union(&feet).into_shape();
 
-    let pcb_center = dvec2(PCB_WIDTH / 2.0, PCB_HEIGHT / 2.0);
+    case.write_step("keyboard.step").unwrap();
 
-    let upper_left_foot_pos = pcb_center + dvec2(-90.0, 18.5);
-    let bottom_left_foot_pos = upper_left_foot_pos + dvec2(14.0, -55.3);
-
-    let upper_left_foot = case_foot(upper_left_foot_pos, true);
-    let upper_right_foot = case_foot(upper_left_foot_pos + dvec2(171.1, 0.0), true);
-    let bottom_left_foot = case_foot(bottom_left_foot_pos, false);
-    let bottom_right_foot = case_foot(bottom_left_foot_pos + dvec2(152.1, 0.0), false);
-
-    // Temporary plate to hold the feet
-    let corner_1 = DVec3::new(pcb_center.x - 120.0, pcb_center.y - 35.0 - 10.0, 0.0);
-    let corner_2 = DVec3::new(pcb_center.x + 120.0, pcb_center.y + 35.0 - 10.0, 0.5);
-    let plate = Shape::box_from_corners(corner_1, corner_2);
-
-    let feet = upper_left_foot
-        .union(&upper_right_foot)
-        .union(&bottom_left_foot)
-        .union(&bottom_right_foot)
-        .union(&plate)
-        .into_shape();
-
-    feet.write_step("keyboard_case_feet_plate_test.step").unwrap();
-
-    feet
+    case
 }

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -64,7 +64,7 @@ const SUPPORT_POST_RADIUS: f64 = 2.0;
 
 // http://www.metrication.com/engineering/threads.html
 const SUPPORT_POST_DRILL_RADIUS: f64 = 0.8;
-const SUPPORT_POST_DIST_FROM_EDGE: f64 = 2.5 + PCB_DIMENSION_TOLERANCE;
+const SUPPORT_POST_DIST_FROM_EDGE: f64 = 2.5;
 
 #[allow(unused)]
 enum PostDirection {

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -455,7 +455,7 @@ pub fn shape() -> Shape {
     // shape.write_stl("keyboard_half.stl").unwrap();
 
     let foot_z_extrude = 2.5;
-    let feet_indentation = case_feet(CASE_FOOT_THICKNESS + 0.15, foot_z_extrude);
+    let feet_indentation = case_feet(CASE_FOOT_THICKNESS + 0.1, foot_z_extrude);
     let feet = case_feet(CASE_FOOT_THICKNESS, -foot_z_extrude * 2.0);
 
     let case = case.subtract(&feet_indentation).into_shape();

--- a/examples/src/keyboard_case.rs
+++ b/examples/src/keyboard_case.rs
@@ -139,14 +139,6 @@ const SUPPORT_POSTS: &[SupportPost] = &[
         pos: DVec2::new(204.75, PCB_TOP - SUPPORT_POST_DIST_FROM_EDGE),
         direction: PostDirection::Up,
     },
-    // SupportPost {
-    //     pos: DVec2::new(PCB_LEFT + SUPPORT_POST_DIST_FROM_EDGE, -57.15),
-    //     direction: PostDirection::Left,
-    // },
-    // SupportPost {
-    //     pos: DVec2::new(PCB_RIGHT - SUPPORT_POST_DIST_FROM_EDGE, -57.15),
-    //     direction: PostDirection::Right,
-    // },
     SupportPost {
         pos: DVec2::new(80.95, PCB_BOTTOM + SUPPORT_POST_DIST_FROM_EDGE),
         direction: PostDirection::Down,
@@ -195,11 +187,6 @@ const PINHOLE_BUTTON_RADIUS: f64 = 1.1;
 const PINHOLE_LOCATIONS: &[DVec2] = &[DVec2::new(35.85, -53.95), DVec2::new(8.425, -86.075)];
 
 fn case_outer_box() -> Shape {
-    // let corner_1 = DVec3::new(CASE_LEFT, CASE_TOP, CASE_BOTTOM_Z);
-    // let corner_2 = DVec3::new(CASE_RIGHT, CASE_BOTTOM, CASE_TOP_Z);
-
-    // let shape = Shape::box_from_corners(corner_1, corner_2);
-
     let mut workplane = Workplane::xy();
     workplane.set_translation(dvec3(0.0, 0.0, CASE_BOTTOM_Z));
 
@@ -222,11 +209,6 @@ fn case_outer_box() -> Shape {
 }
 
 fn case_inner_box() -> Shape {
-    // let corner_1 = DVec3::new(PCB_LEFT, PCB_TOP, CASE_FLOOR_Z);
-    // let corner_2 = DVec3::new(PCB_RIGHT, PCB_BOTTOM, CASE_TOP_Z);
-
-    // Shape::box_from_corners(corner_1, corner_2)
-
     let mut workplane = Workplane::xy();
     workplane.set_translation(dvec3(0.0, 0.0, CASE_FLOOR_Z));
 
@@ -310,7 +292,7 @@ fn pcb_usb_overhang() -> Shape {
             DVec3::new(33.337, PCB_TOP - PCB_SHELF_THICKNESS_TOP, start),
             DVec3::new(19.05, PCB_TOP - PCB_SHELF_THICKNESS_TOP, start),
         ],
-        PCB_TOP_Z - start, // PCB_THICKNESS + 0.5,
+        PCB_TOP_Z - start,
     )
     .unwrap()
     .into()
@@ -324,7 +306,6 @@ pub fn shape() -> Shape {
 
     let shape = case_outer_box()
         .subtract(&inner_box)
-        // .fillet(1.3)
         .union(&top_shelf)
         .union(&bottom_shelf)
         .subtract(&usb_cutout);
@@ -337,8 +318,6 @@ pub fn shape() -> Shape {
     let shape = shape.chamfer_edges(1.0, new_edges);
 
     let mut shape = shape.into_shape();
-    // .chamfer_new_edges(0.5)
-    // .into_shape();
 
     for support_post in SUPPORT_POSTS {
         shape = shape.union(&support_post.shape()).into();


### PR DESCRIPTION
TODO

- [x] Adjust the location of the support posts
- [x] Move the top two feet positions up one "row", and change them from a T-shape to a line shape to fit in the grooves better
  - [x] Move the "bars" north by 0.1mm or so, and reduce their thickness by 0.1 or 0.2 mm
- [x] Shift the feet a bit more "north" (by 5mm) so the keyboard is overall closer to the trackpad
- [x] The bottom feet should be shifted down by 0.1 or 0.2mm