### PR TITLE
First pass at using wit-bindgen/wasmtime and WIT interfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
 members = [
-    "crates/kicad-parser",
+    "crates/kicad-parser", "crates/model-api",
     "crates/opencascade",
     "crates/opencascade-sys",
-    "crates/viewer",
+    "crates/viewer", "crates/wasm-example",
     "examples",
 ]
 

--- a/crates/model-api/Cargo.toml
+++ b/crates/model-api/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-wit-bindgen = "0.24"
+wit-bindgen = "0.26"
 glam = { version = "0.24", features = ["bytemuck"] }

--- a/crates/model-api/Cargo.toml
+++ b/crates/model-api/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "model-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wit-bindgen = "0.24"
+glam = { version = "0.24", features = ["bytemuck"] }

--- a/crates/model-api/src/angle.rs
+++ b/crates/model-api/src/angle.rs
@@ -1,0 +1,96 @@
+use glam::{dvec3, DVec3};
+use std::ops::{Div, Mul};
+
+#[derive(Debug, Copy, Clone)]
+pub enum Angle {
+    Radians(f64),
+    Degrees(f64),
+}
+
+impl Angle {
+    pub fn radians(self) -> f64 {
+        match self {
+            Self::Radians(r) => r,
+            Self::Degrees(d) => (d * std::f64::consts::PI) / 180.0,
+        }
+    }
+
+    pub fn degrees(self) -> f64 {
+        match self {
+            Self::Radians(r) => (r * 180.0) / std::f64::consts::PI,
+            Self::Degrees(d) => d,
+        }
+    }
+}
+
+impl Mul<f64> for Angle {
+    type Output = Angle;
+
+    fn mul(self, multiplier: f64) -> Self::Output {
+        match self {
+            Self::Radians(angle) => Self::Radians(angle * multiplier),
+            Self::Degrees(angle) => Self::Degrees(angle * multiplier),
+        }
+    }
+}
+
+impl Div<f64> for Angle {
+    type Output = Angle;
+
+    fn div(self, divisor: f64) -> Self::Output {
+        match self {
+            Self::Radians(angle) => Self::Radians(angle / divisor),
+            Self::Degrees(angle) => Self::Degrees(angle / divisor),
+        }
+    }
+}
+
+pub trait ToAngle {
+    fn degrees(&self) -> Angle;
+    fn radians(&self) -> Angle;
+}
+
+impl<T: Into<f64> + Copy> ToAngle for T {
+    fn degrees(&self) -> Angle {
+        Angle::Degrees((*self).into())
+    }
+
+    fn radians(&self) -> Angle {
+        Angle::Radians((*self).into())
+    }
+}
+
+/// Represents rotation on the X, Y, and Z axes. Also known
+/// as Euler angle representation.
+#[derive(Debug, Copy, Clone)]
+pub struct RVec {
+    pub x: Angle,
+    pub y: Angle,
+    pub z: Angle,
+}
+
+impl RVec {
+    pub fn radians(&self) -> DVec3 {
+        dvec3(self.x.radians(), self.y.radians(), self.z.radians())
+    }
+
+    pub fn degrees(&self) -> DVec3 {
+        dvec3(self.x.degrees(), self.y.degrees(), self.z.degrees())
+    }
+
+    pub fn x(x: Angle) -> Self {
+        RVec { x, y: 0.degrees(), z: 0.degrees() }
+    }
+
+    pub fn y(y: Angle) -> Self {
+        RVec { x: 0.degrees(), y, z: 0.degrees() }
+    }
+
+    pub fn z(z: Angle) -> Self {
+        RVec { x: 0.degrees(), y: 0.degrees(), z }
+    }
+}
+
+pub fn rvec(x: Angle, y: Angle, z: Angle) -> RVec {
+    RVec { x, y, z }
+}

--- a/crates/model-api/src/lib.rs
+++ b/crates/model-api/src/lib.rs
@@ -1,3 +1,5 @@
+use crate::primitives::Shape;
+
 pub mod angle;
 pub mod primitives;
 pub mod wasm;
@@ -8,5 +10,5 @@ pub trait Model: Send + Sync {
     where
         Self: Sized;
 
-    fn create_model(&mut self);
+    fn create_model(&mut self) -> Shape;
 }

--- a/crates/model-api/src/lib.rs
+++ b/crates/model-api/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod angle;
+pub mod primitives;
+pub mod wasm;
+pub mod workplane;
+
+pub trait Model: Send + Sync {
+    fn new() -> Self
+    where
+        Self: Sized;
+
+    fn create_model(&mut self);
+}

--- a/crates/model-api/src/primitives.rs
+++ b/crates/model-api/src/primitives.rs
@@ -1,5 +1,7 @@
 mod edge;
+mod shape;
 mod wire;
 
 pub use edge::*;
+pub use shape::*;
 pub use wire::*;

--- a/crates/model-api/src/primitives.rs
+++ b/crates/model-api/src/primitives.rs
@@ -1,3 +1,6 @@
+use crate::wasm;
+use glam::DVec3;
+
 mod compound;
 mod edge;
 mod face;
@@ -13,3 +16,90 @@ pub use shape::*;
 pub use shell::*;
 pub use solid::*;
 pub use wire::*;
+
+pub trait IntoShape {
+    fn into_shape(self) -> Shape;
+}
+
+impl<T: Into<Shape>> IntoShape for T {
+    fn into_shape(self) -> Shape {
+        self.into()
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Direction {
+    PosX,
+    NegX,
+    PosY,
+    NegY,
+    PosZ,
+    NegZ,
+    Custom(DVec3),
+}
+
+impl Direction {
+    pub fn normalized_vec(&self) -> DVec3 {
+        match self {
+            Self::PosX => DVec3::X,
+            Self::NegX => DVec3::NEG_X,
+            Self::PosY => DVec3::Y,
+            Self::NegY => DVec3::NEG_Y,
+            Self::PosZ => DVec3::Z,
+            Self::NegZ => DVec3::NEG_Z,
+            Self::Custom(dir) => dir.normalize(),
+        }
+    }
+}
+
+pub struct EdgeIterator {
+    iterator: wasm::EdgeIterator,
+}
+
+impl EdgeIterator {
+    pub fn new(face: &Face) -> Self {
+        Self { iterator: wasm::EdgeIterator::new(&face.inner) }
+    }
+}
+
+impl Iterator for EdgeIterator {
+    type Item = Edge;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iterator.next().map(|inner_edge| Edge { inner: inner_edge })
+    }
+}
+
+pub struct FaceIterator {
+    iterator: wasm::FaceIterator,
+}
+
+impl FaceIterator {
+    pub fn new(shape: &Shape) -> Self {
+        Self { iterator: wasm::FaceIterator::new(&shape.inner) }
+    }
+
+    pub fn farthest(self, direction: Direction) -> Face {
+        self.try_farthest(direction).unwrap()
+    }
+
+    pub fn try_farthest(self, direction: Direction) -> Option<Face> {
+        let normalized_dir = direction.normalized_vec();
+
+        self.max_by(|face_1, face_2| {
+            let dist_1 = face_1.center_of_mass().dot(normalized_dir);
+            let dist_2 = face_2.center_of_mass().dot(normalized_dir);
+
+            PartialOrd::partial_cmp(&dist_1, &dist_2)
+                .expect("Face center of masses should contain no NaNs")
+        })
+    }
+}
+
+impl Iterator for FaceIterator {
+    type Item = Face;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iterator.next().map(|inner_face| Face { inner: inner_face })
+    }
+}

--- a/crates/model-api/src/primitives.rs
+++ b/crates/model-api/src/primitives.rs
@@ -1,15 +1,15 @@
+mod compound;
 mod edge;
 mod face;
 mod shape;
 mod shell;
 mod solid;
-mod compound;
 mod wire;
 
+pub use compound::*;
 pub use edge::*;
 pub use face::*;
 pub use shape::*;
 pub use shell::*;
 pub use solid::*;
-pub use compound::*;
 pub use wire::*;

--- a/crates/model-api/src/primitives.rs
+++ b/crates/model-api/src/primitives.rs
@@ -1,7 +1,15 @@
 mod edge;
+mod face;
 mod shape;
+mod shell;
+mod solid;
+mod compound;
 mod wire;
 
 pub use edge::*;
+pub use face::*;
 pub use shape::*;
+pub use shell::*;
+pub use solid::*;
+pub use compound::*;
 pub use wire::*;

--- a/crates/model-api/src/primitives.rs
+++ b/crates/model-api/src/primitives.rs
@@ -1,0 +1,5 @@
+mod edge;
+mod wire;
+
+pub use edge::*;
+pub use wire::*;

--- a/crates/model-api/src/primitives/compound.rs
+++ b/crates/model-api/src/primitives/compound.rs
@@ -1,7 +1,7 @@
 use crate::wasm;
 
 pub struct Compound {
-    pub(crate) inner: wasm::Compound,
+    pub(crate) _inner: wasm::Compound,
 }
 
 impl AsRef<Compound> for Compound {

--- a/crates/model-api/src/primitives/compound.rs
+++ b/crates/model-api/src/primitives/compound.rs
@@ -1,0 +1,15 @@
+use crate::{primitives::Edge, wasm, wasm::WasmCompound};
+
+pub struct Compound {
+    pub(crate) inner: WasmCompound,
+}
+
+impl AsRef<Compound> for Compound {
+    fn as_ref(&self) -> &Compound {
+        self
+    }
+}
+
+impl Compound {
+    
+}

--- a/crates/model-api/src/primitives/compound.rs
+++ b/crates/model-api/src/primitives/compound.rs
@@ -10,6 +10,4 @@ impl AsRef<Compound> for Compound {
     }
 }
 
-impl Compound {
-    
-}
+impl Compound {}

--- a/crates/model-api/src/primitives/compound.rs
+++ b/crates/model-api/src/primitives/compound.rs
@@ -1,7 +1,7 @@
 use crate::wasm;
 
 pub struct Compound {
-    pub(crate) _inner: wasm::Compound,
+    pub(crate) inner: wasm::Compound,
 }
 
 impl AsRef<Compound> for Compound {

--- a/crates/model-api/src/primitives/compound.rs
+++ b/crates/model-api/src/primitives/compound.rs
@@ -1,7 +1,7 @@
-use crate::{primitives::Edge, wasm, wasm::WasmCompound};
+use crate::wasm;
 
 pub struct Compound {
-    pub(crate) inner: WasmCompound,
+    pub(crate) inner: wasm::Compound,
 }
 
 impl AsRef<Compound> for Compound {

--- a/crates/model-api/src/primitives/edge.rs
+++ b/crates/model-api/src/primitives/edge.rs
@@ -1,0 +1,22 @@
+use crate::wasm::new_line_segment;
+use glam::DVec3;
+
+pub struct EdgeId(pub(crate) u64);
+
+pub struct Edge {
+    pub(crate) inner: EdgeId,
+}
+
+impl AsRef<Edge> for Edge {
+    fn as_ref(&self) -> &Edge {
+        self
+    }
+}
+
+impl Edge {
+    pub fn segment(p1: DVec3, p2: DVec3) -> Self {
+        let id = new_line_segment(p1.into(), p2.into());
+
+        Self { inner: EdgeId(id) }
+    }
+}

--- a/crates/model-api/src/primitives/edge.rs
+++ b/crates/model-api/src/primitives/edge.rs
@@ -1,10 +1,8 @@
-use crate::wasm::new_line_segment;
+use crate::wasm::WasmEdge;
 use glam::DVec3;
 
-pub struct EdgeId(pub(crate) u64);
-
 pub struct Edge {
-    pub(crate) inner: EdgeId,
+    pub(crate) inner: WasmEdge,
 }
 
 impl AsRef<Edge> for Edge {
@@ -15,8 +13,8 @@ impl AsRef<Edge> for Edge {
 
 impl Edge {
     pub fn segment(p1: DVec3, p2: DVec3) -> Self {
-        let id = new_line_segment(p1.into(), p2.into());
+        let inner = WasmEdge::segment(p1.into(), p2.into());
 
-        Self { inner: EdgeId(id) }
+        Edge { inner }
     }
 }

--- a/crates/model-api/src/primitives/edge.rs
+++ b/crates/model-api/src/primitives/edge.rs
@@ -1,8 +1,8 @@
-use crate::wasm::WasmEdge;
+use crate::wasm;
 use glam::DVec3;
 
 pub struct Edge {
-    pub(crate) inner: WasmEdge,
+    pub(crate) inner: wasm::Edge,
 }
 
 impl AsRef<Edge> for Edge {
@@ -13,7 +13,7 @@ impl AsRef<Edge> for Edge {
 
 impl Edge {
     pub fn segment(p1: DVec3, p2: DVec3) -> Self {
-        let inner = WasmEdge::segment(p1.into(), p2.into());
+        let inner = wasm::Edge::segment(p1.into(), p2.into());
 
         Edge { inner }
     }

--- a/crates/model-api/src/primitives/face.rs
+++ b/crates/model-api/src/primitives/face.rs
@@ -1,4 +1,4 @@
-use crate::wasm::WasmFace;
+use crate::{primitives::Wire, wasm, wasm::WasmFace};
 
 pub struct Face {
     pub(crate) inner: WasmFace,
@@ -10,4 +10,22 @@ impl AsRef<Face> for Face {
     }
 }
 
-impl Face {}
+impl Face {
+    pub fn from_wire(wire: &Wire) -> Self {
+        let host_face = wasm::WasmFace::from_wire(&wire.inner);
+
+        Self { inner: host_face }
+    }
+
+    pub fn fillet(&self, radius: f64) -> Self {
+        let host_face = self.inner.fillet(radius);
+
+        Self { inner: host_face }
+    }
+
+    pub fn outer_wire(&self) -> Wire {
+        let host_wire = self.inner.outer_wire();
+
+        Wire { inner: host_wire }
+    }
+}

--- a/crates/model-api/src/primitives/face.rs
+++ b/crates/model-api/src/primitives/face.rs
@@ -1,0 +1,13 @@
+use crate::wasm::WasmFace;
+
+pub struct Face {
+    pub(crate) inner: WasmFace,
+}
+
+impl AsRef<Face> for Face {
+    fn as_ref(&self) -> &Face {
+        self
+    }
+}
+
+impl Face {}

--- a/crates/model-api/src/primitives/face.rs
+++ b/crates/model-api/src/primitives/face.rs
@@ -1,7 +1,7 @@
-use crate::{primitives::Wire, wasm, wasm::WasmFace};
+use crate::{primitives::Wire, wasm};
 
 pub struct Face {
-    pub(crate) inner: WasmFace,
+    pub(crate) inner: wasm::Face,
 }
 
 impl AsRef<Face> for Face {
@@ -12,7 +12,7 @@ impl AsRef<Face> for Face {
 
 impl Face {
     pub fn from_wire(wire: &Wire) -> Self {
-        let host_face = wasm::WasmFace::from_wire(&wire.inner);
+        let host_face = wasm::Face::from_wire(&wire.inner);
 
         Self { inner: host_face }
     }

--- a/crates/model-api/src/primitives/face.rs
+++ b/crates/model-api/src/primitives/face.rs
@@ -1,4 +1,8 @@
-use crate::{primitives::Wire, wasm};
+use crate::{
+    primitives::{EdgeIterator, Solid, Wire},
+    wasm,
+};
+use glam::DVec3;
 
 pub struct Face {
     pub(crate) inner: wasm::Face,
@@ -11,21 +15,38 @@ impl AsRef<Face> for Face {
 }
 
 impl Face {
+    #[must_use]
     pub fn from_wire(wire: &Wire) -> Self {
         let host_face = wasm::Face::from_wire(&wire.inner);
 
         Self { inner: host_face }
     }
 
+    #[must_use]
     pub fn fillet(&self, radius: f64) -> Self {
         let host_face = self.inner.fillet(radius);
 
         Self { inner: host_face }
     }
 
+    #[must_use]
+    pub fn extrude(&self, dir: DVec3) -> Solid {
+        let host_solid = self.inner.extrude(dir.into());
+
+        Solid { inner: host_solid }
+    }
+
     pub fn outer_wire(&self) -> Wire {
         let host_wire = self.inner.outer_wire();
 
         Wire { inner: host_wire }
+    }
+
+    pub fn center_of_mass(&self) -> DVec3 {
+        self.inner.center_of_mass().into()
+    }
+
+    pub fn edges(&self) -> EdgeIterator {
+        EdgeIterator::new(self)
     }
 }

--- a/crates/model-api/src/primitives/shape.rs
+++ b/crates/model-api/src/primitives/shape.rs
@@ -1,7 +1,7 @@
-use crate::{primitives::Wire, wasm, wasm::WasmShape};
+use crate::{primitives::Wire, wasm};
 
 pub struct Shape {
-    pub(crate) inner: WasmShape,
+    pub(crate) inner: wasm::Shape,
 }
 
 impl AsRef<Shape> for Shape {
@@ -12,7 +12,7 @@ impl AsRef<Shape> for Shape {
 
 impl Shape {
     pub fn from_wire(wire: &Wire) -> Self {
-        let shape = wasm::WasmShape::from_wire(&wire.inner);
+        let shape = wasm::Shape::from_wire(&wire.inner);
 
         Self { inner: shape }
     }

--- a/crates/model-api/src/primitives/shape.rs
+++ b/crates/model-api/src/primitives/shape.rs
@@ -1,4 +1,7 @@
-use crate::{primitives::Wire, wasm};
+use crate::{
+    primitives::{Compound, Edge, Face, FaceIterator, Shell, Solid, Wire},
+    wasm,
+};
 
 pub struct Shape {
     pub(crate) inner: wasm::Shape,
@@ -10,10 +13,131 @@ impl AsRef<Shape> for Shape {
     }
 }
 
+impl From<Edge> for Shape {
+    fn from(edge: Edge) -> Self {
+        Shape::from_edge(&edge)
+    }
+}
+
+impl From<&Edge> for Shape {
+    fn from(edge: &Edge) -> Self {
+        Shape::from_edge(edge)
+    }
+}
+
+impl From<Wire> for Shape {
+    fn from(wire: Wire) -> Self {
+        Shape::from_wire(&wire)
+    }
+}
+
+impl From<&Wire> for Shape {
+    fn from(wire: &Wire) -> Self {
+        Shape::from_wire(wire)
+    }
+}
+
+impl From<Face> for Shape {
+    fn from(face: Face) -> Self {
+        Shape::from_face(&face)
+    }
+}
+
+impl From<&Face> for Shape {
+    fn from(face: &Face) -> Self {
+        Shape::from_face(face)
+    }
+}
+
+impl From<Shell> for Shape {
+    fn from(shell: Shell) -> Self {
+        Shape::from_shell(&shell)
+    }
+}
+
+impl From<&Shell> for Shape {
+    fn from(shell: &Shell) -> Self {
+        Shape::from_shell(shell)
+    }
+}
+
+impl From<Solid> for Shape {
+    fn from(solid: Solid) -> Self {
+        Shape::from_solid(&solid)
+    }
+}
+
+impl From<&Solid> for Shape {
+    fn from(solid: &Solid) -> Self {
+        Shape::from_solid(solid)
+    }
+}
+
+impl From<Compound> for Shape {
+    fn from(compound: Compound) -> Self {
+        Shape::from_compound(&compound)
+    }
+}
+
+impl From<&Compound> for Shape {
+    fn from(compound: &Compound) -> Self {
+        Shape::from_compound(compound)
+    }
+}
+
 impl Shape {
+    pub fn from_edge(edge: &Edge) -> Self {
+        let shape = wasm::Shape::from_edge(&edge.inner);
+
+        Self { inner: shape }
+    }
+
     pub fn from_wire(wire: &Wire) -> Self {
         let shape = wasm::Shape::from_wire(&wire.inner);
 
         Self { inner: shape }
+    }
+
+    pub fn from_face(face: &Face) -> Self {
+        let shape = wasm::Shape::from_face(&face.inner);
+
+        Self { inner: shape }
+    }
+
+    pub fn from_shell(shell: &Shell) -> Self {
+        let shape = wasm::Shape::from_shell(&shell.inner);
+
+        Self { inner: shape }
+    }
+
+    pub fn from_solid(solid: &Solid) -> Self {
+        let shape = wasm::Shape::from_solid(&solid.inner);
+
+        Self { inner: shape }
+    }
+
+    pub fn from_compound(compound: &Compound) -> Self {
+        let shape = wasm::Shape::from_compound(&compound.inner);
+
+        Self { inner: shape }
+    }
+
+    // #[must_use]
+    // pub fn chamfer_edges<T: AsRef<Edge>>(
+    //     &self,
+    //     distance: f64,
+    //     edges: impl IntoIterator<Item = T>,
+    // ) -> Self {
+    //     let mut make_chamfer = ffi::BRepFilletAPI_MakeChamfer_ctor(&self.inner);
+
+    //     for edge in edges.into_iter() {
+    //         make_chamfer.pin_mut().add_edge(distance, &edge.as_ref().inner);
+    //     }
+
+    //     Self::from_shape(make_chamfer.pin_mut().Shape())
+    // }
+
+    pub fn faces(&self) -> FaceIterator {
+        FaceIterator::new(self)
     }
 }

--- a/crates/model-api/src/primitives/shape.rs
+++ b/crates/model-api/src/primitives/shape.rs
@@ -1,0 +1,19 @@
+use crate::{primitives::Wire, wasm, wasm::WasmShape};
+
+pub struct Shape {
+    pub(crate) inner: WasmShape,
+}
+
+impl AsRef<Shape> for Shape {
+    fn as_ref(&self) -> &Shape {
+        self
+    }
+}
+
+impl Shape {
+    pub fn from_wire(wire: &Wire) -> Self {
+        let shape = wasm::WasmShape::from_wire(&wire.inner);
+
+        Self { inner: shape }
+    }
+}

--- a/crates/model-api/src/primitives/shape.rs
+++ b/crates/model-api/src/primitives/shape.rs
@@ -122,20 +122,20 @@ impl Shape {
         Self { inner: shape }
     }
 
-    // #[must_use]
-    // pub fn chamfer_edges<T: AsRef<Edge>>(
-    //     &self,
-    //     distance: f64,
-    //     edges: impl IntoIterator<Item = T>,
-    // ) -> Self {
-    //     let mut make_chamfer = ffi::BRepFilletAPI_MakeChamfer_ctor(&self.inner);
+    #[must_use]
+    pub fn chamfer_edges<T: AsRef<Edge>>(
+        &self,
+        distance: f64,
+        edges: impl IntoIterator<Item = T>,
+    ) -> Self {
+        let make_chamfer = wasm::ChamferMaker::new(&self.inner);
 
-    //     for edge in edges.into_iter() {
-    //         make_chamfer.pin_mut().add_edge(distance, &edge.as_ref().inner);
-    //     }
+        for edge in edges.into_iter() {
+            make_chamfer.add_edge(distance, &edge.as_ref().inner);
+        }
 
-    //     Self::from_shape(make_chamfer.pin_mut().Shape())
-    // }
+        Self { inner: make_chamfer.build() }
+    }
 
     pub fn faces(&self) -> FaceIterator {
         FaceIterator::new(self)

--- a/crates/model-api/src/primitives/shell.rs
+++ b/crates/model-api/src/primitives/shell.rs
@@ -1,7 +1,7 @@
-use crate::{primitives::Edge, wasm, wasm::WasmShell};
+use crate::wasm;
 
 pub struct Shell {
-    pub(crate) inner: WasmShell,
+    pub(crate) inner: wasm::Shell,
 }
 
 impl AsRef<Shell> for Shell {

--- a/crates/model-api/src/primitives/shell.rs
+++ b/crates/model-api/src/primitives/shell.rs
@@ -1,7 +1,7 @@
 use crate::wasm;
 
 pub struct Shell {
-    pub(crate) _inner: wasm::Shell,
+    pub(crate) inner: wasm::Shell,
 }
 
 impl AsRef<Shell> for Shell {

--- a/crates/model-api/src/primitives/shell.rs
+++ b/crates/model-api/src/primitives/shell.rs
@@ -1,7 +1,7 @@
 use crate::wasm;
 
 pub struct Shell {
-    pub(crate) inner: wasm::Shell,
+    pub(crate) _inner: wasm::Shell,
 }
 
 impl AsRef<Shell> for Shell {

--- a/crates/model-api/src/primitives/shell.rs
+++ b/crates/model-api/src/primitives/shell.rs
@@ -1,0 +1,13 @@
+use crate::{primitives::Edge, wasm, wasm::WasmShell};
+
+pub struct Shell {
+    pub(crate) inner: WasmShell,
+}
+
+impl AsRef<Shell> for Shell {
+    fn as_ref(&self) -> &Shell {
+        self
+    }
+}
+
+impl Shell {}

--- a/crates/model-api/src/primitives/solid.rs
+++ b/crates/model-api/src/primitives/solid.rs
@@ -1,7 +1,7 @@
 use crate::wasm;
 
 pub struct Solid {
-    pub(crate) inner: wasm::Solid,
+    pub(crate) _inner: wasm::Solid,
 }
 
 impl AsRef<Solid> for Solid {

--- a/crates/model-api/src/primitives/solid.rs
+++ b/crates/model-api/src/primitives/solid.rs
@@ -1,0 +1,13 @@
+use crate::{primitives::Edge, wasm, wasm::WasmSolid};
+
+pub struct Solid {
+    pub(crate) inner: WasmSolid,
+}
+
+impl AsRef<Solid> for Solid {
+    fn as_ref(&self) -> &Solid {
+        self
+    }
+}
+
+impl Solid {}

--- a/crates/model-api/src/primitives/solid.rs
+++ b/crates/model-api/src/primitives/solid.rs
@@ -1,7 +1,7 @@
 use crate::wasm;
 
 pub struct Solid {
-    pub(crate) _inner: wasm::Solid,
+    pub(crate) inner: wasm::Solid,
 }
 
 impl AsRef<Solid> for Solid {

--- a/crates/model-api/src/primitives/solid.rs
+++ b/crates/model-api/src/primitives/solid.rs
@@ -1,7 +1,7 @@
-use crate::{primitives::Edge, wasm, wasm::WasmSolid};
+use crate::wasm;
 
 pub struct Solid {
-    pub(crate) inner: WasmSolid,
+    pub(crate) inner: wasm::Solid,
 }
 
 impl AsRef<Solid> for Solid {

--- a/crates/model-api/src/primitives/wire.rs
+++ b/crates/model-api/src/primitives/wire.rs
@@ -1,4 +1,8 @@
-use crate::{primitives::Edge, wasm, wasm::WasmWire};
+use crate::{
+    primitives::{Edge, Face},
+    wasm,
+    wasm::WasmWire,
+};
 
 pub struct Wire {
     pub(crate) inner: WasmWire,
@@ -19,5 +23,10 @@ impl Wire {
         }
 
         Self { inner: wire_builder.build() }
+    }
+
+    pub fn fillet(&self, radius: f64) -> Self {
+        let face = Face::from_wire(self).fillet(radius);
+        face.outer_wire()
     }
 }

--- a/crates/model-api/src/primitives/wire.rs
+++ b/crates/model-api/src/primitives/wire.rs
@@ -1,11 +1,10 @@
 use crate::{
     primitives::{Edge, Face},
     wasm,
-    wasm::WasmWire,
 };
 
 pub struct Wire {
-    pub(crate) inner: WasmWire,
+    pub(crate) inner: wasm::Wire,
 }
 
 impl AsRef<Wire> for Wire {
@@ -16,7 +15,7 @@ impl AsRef<Wire> for Wire {
 
 impl Wire {
     pub fn from_edges<'a>(edges: impl IntoIterator<Item = &'a Edge>) -> Self {
-        let wire_builder = wasm::WasmWireBuilder::new();
+        let wire_builder = wasm::WireBuilder::new();
 
         for edge in edges.into_iter() {
             wire_builder.add_edge(&edge.inner);

--- a/crates/model-api/src/primitives/wire.rs
+++ b/crates/model-api/src/primitives/wire.rs
@@ -28,4 +28,8 @@ impl Wire {
         let face = Face::from_wire(self).fillet(radius);
         face.outer_wire()
     }
+
+    pub fn to_face(&self) -> Face {
+        Face::from_wire(self)
+    }
 }

--- a/crates/model-api/src/primitives/wire.rs
+++ b/crates/model-api/src/primitives/wire.rs
@@ -1,0 +1,25 @@
+use crate::{primitives::Edge, wasm};
+
+pub struct WireId(pub(crate) u64);
+
+pub struct Wire {
+    pub(crate) inner: WireId,
+}
+
+impl AsRef<Wire> for Wire {
+    fn as_ref(&self) -> &Wire {
+        self
+    }
+}
+
+impl Wire {
+    pub fn from_edges<'a>(edges: impl IntoIterator<Item = &'a Edge>) -> Self {
+        let wire_builder = wasm::new_wire_builder();
+
+        for edge in edges.into_iter() {
+            wasm::wire_builder_add_edge(wire_builder, edge.inner.0);
+        }
+
+        Self { inner: WireId(wasm::wire_builder_build(wire_builder)) }
+    }
+}

--- a/crates/model-api/src/primitives/wire.rs
+++ b/crates/model-api/src/primitives/wire.rs
@@ -1,9 +1,7 @@
-use crate::{primitives::Edge, wasm};
-
-pub struct WireId(pub(crate) u64);
+use crate::{primitives::Edge, wasm, wasm::WasmWire};
 
 pub struct Wire {
-    pub(crate) inner: WireId,
+    pub(crate) inner: WasmWire,
 }
 
 impl AsRef<Wire> for Wire {
@@ -14,12 +12,12 @@ impl AsRef<Wire> for Wire {
 
 impl Wire {
     pub fn from_edges<'a>(edges: impl IntoIterator<Item = &'a Edge>) -> Self {
-        let wire_builder = wasm::new_wire_builder();
+        let wire_builder = wasm::WasmWireBuilder::new();
 
         for edge in edges.into_iter() {
-            wasm::wire_builder_add_edge(wire_builder, edge.inner.0);
+            wire_builder.add_edge(&edge.inner);
         }
 
-        Self { inner: WireId(wasm::wire_builder_build(wire_builder)) }
+        Self { inner: wire_builder.build() }
     }
 }

--- a/crates/model-api/src/wasm.rs
+++ b/crates/model-api/src/wasm.rs
@@ -1,0 +1,60 @@
+use crate::Model;
+use glam::DVec3;
+
+// Use a procedural macro to generate bindings for the world we specified in
+// `host.wit`
+wit_bindgen::generate!({
+    // the name of the world in the `*.wit` input file
+    world: "model-world",
+    // "init-model" is skipped because it is exported manually below.
+    skip: ["init-model"],
+});
+
+impl From<DVec3> for Point3 {
+    fn from(p: DVec3) -> Self {
+        Self { x: p.x, y: p.y, z: p.z }
+    }
+}
+
+impl From<Point3> for DVec3 {
+    fn from(p: Point3) -> Self {
+        Self { x: p.x, y: p.y, z: p.z }
+    }
+}
+
+// Define a custom type and implement the generated `Guest` trait for it which
+// represents implementing all the necessary exported interfaces for this
+// component.
+pub struct CadModelCode;
+
+impl Guest for CadModelCode {
+    fn run() {
+        print("Hello, world!");
+        model().create_model();
+    }
+}
+
+static mut MODEL: Option<Box<dyn Model>> = None;
+
+#[doc(hidden)]
+pub fn register_model(build_model: fn() -> Box<dyn Model>) {
+    unsafe { MODEL = Some((build_model)()) }
+}
+
+fn model() -> &'static mut dyn Model {
+    unsafe { MODEL.as_deref_mut().unwrap() }
+}
+
+#[macro_export]
+macro_rules! register_model {
+    ($model_type:ty) => {
+        #[export_name = "init-model"]
+        pub extern "C" fn __init_model() {
+            model_api::wasm::register_model(|| Box::new(<$model_type as model_api::Model>::new()));
+        }
+    };
+}
+
+// export! defines that the `CadModelCode` struct defined below is going to define
+// the exports of the `world`, namely the `run` function.
+export!(CadModelCode);

--- a/crates/model-api/src/wasm.rs
+++ b/crates/model-api/src/wasm.rs
@@ -28,7 +28,7 @@ impl From<Point3> for DVec3 {
 pub struct CadModelCode;
 
 impl Guest for CadModelCode {
-    fn run() -> WasmShape {
+    fn run() -> Shape {
         print("Hello, world!");
         let user_shape = model().create_model();
 

--- a/crates/model-api/src/wasm.rs
+++ b/crates/model-api/src/wasm.rs
@@ -28,9 +28,11 @@ impl From<Point3> for DVec3 {
 pub struct CadModelCode;
 
 impl Guest for CadModelCode {
-    fn run() {
+    fn run() -> WasmShape {
         print("Hello, world!");
-        model().create_model();
+        let user_shape = model().create_model();
+
+        user_shape.inner
     }
 }
 

--- a/crates/model-api/src/workplane.rs
+++ b/crates/model-api/src/workplane.rs
@@ -1,0 +1,204 @@
+use crate::{
+    angle::{Angle, RVec},
+    primitives::{Edge, Wire},
+};
+use glam::{dvec3, DAffine3, DMat3, DVec3, EulerRot};
+
+#[derive(Debug, Copy, Clone)]
+pub enum Plane {
+    XY,
+    YZ,
+    ZX,
+    XZ,
+    YX,
+    ZY,
+    Front,
+    Back,
+    Left,
+    Right,
+    Top,
+    Bottom,
+    Custom { x_dir: (f64, f64, f64), normal_dir: (f64, f64, f64) },
+}
+
+impl Plane {
+    pub fn transform_point(&self, point: DVec3) -> DVec3 {
+        self.transform().transform_point3(point)
+    }
+
+    pub fn transform(&self) -> DAffine3 {
+        match self {
+            Self::XY => DAffine3::from_cols(DVec3::X, DVec3::Y, DVec3::Z, DVec3::ZERO),
+            Self::YZ => DAffine3::from_cols(DVec3::Y, DVec3::Z, DVec3::X, DVec3::ZERO),
+            Self::ZX => DAffine3::from_cols(DVec3::Z, DVec3::X, DVec3::Y, DVec3::ZERO),
+            Self::XZ => DAffine3::from_cols(DVec3::X, DVec3::Z, DVec3::NEG_Y, DVec3::ZERO),
+            Self::YX => DAffine3::from_cols(DVec3::Y, DVec3::X, DVec3::NEG_Z, DVec3::ZERO),
+            Self::ZY => DAffine3::from_cols(DVec3::Z, DVec3::Y, DVec3::NEG_X, DVec3::ZERO),
+            Self::Front => DAffine3::from_cols(DVec3::X, DVec3::Y, DVec3::Z, DVec3::ZERO),
+            Self::Back => DAffine3::from_cols(DVec3::NEG_X, DVec3::Y, DVec3::NEG_Z, DVec3::ZERO),
+            Self::Left => DAffine3::from_cols(DVec3::Z, DVec3::Y, DVec3::NEG_X, DVec3::ZERO),
+            Self::Right => DAffine3::from_cols(DVec3::NEG_Z, DVec3::Y, DVec3::X, DVec3::ZERO),
+            Self::Top => DAffine3::from_cols(DVec3::X, DVec3::NEG_Z, DVec3::Y, DVec3::ZERO),
+            Self::Bottom => DAffine3::from_cols(DVec3::X, DVec3::Z, DVec3::NEG_Y, DVec3::ZERO),
+            Self::Custom { x_dir, normal_dir } => {
+                let x_axis = dvec3(x_dir.0, x_dir.1, x_dir.2).normalize();
+                let z_axis = dvec3(normal_dir.0, normal_dir.1, normal_dir.2).normalize();
+                let y_axis = z_axis.cross(x_axis).normalize();
+
+                DAffine3::from_cols(x_axis, y_axis, z_axis, DVec3::ZERO)
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Workplane {
+    transform: DAffine3,
+}
+
+impl Workplane {
+    pub fn new(x_dir: DVec3, normal_dir: DVec3) -> Self {
+        Self {
+            transform: Plane::Custom {
+                x_dir: x_dir.normalize().into(),
+                normal_dir: normal_dir.normalize().into(),
+            }
+            .transform(),
+        }
+    }
+
+    pub fn xy() -> Self {
+        Self { transform: Plane::XY.transform() }
+    }
+
+    pub fn yz() -> Self {
+        Self { transform: Plane::YZ.transform() }
+    }
+
+    pub fn zx() -> Self {
+        Self { transform: Plane::ZX.transform() }
+    }
+
+    pub fn xz() -> Self {
+        Self { transform: Plane::XZ.transform() }
+    }
+
+    pub fn zy() -> Self {
+        Self { transform: Plane::ZY.transform() }
+    }
+
+    pub fn yx() -> Self {
+        Self { transform: Plane::YX.transform() }
+    }
+
+    pub fn origin(&self) -> DVec3 {
+        self.transform.translation
+    }
+
+    pub fn normal(&self) -> DVec3 {
+        self.transform.matrix3.z_axis
+    }
+
+    pub fn x_dir(&self) -> DVec3 {
+        self.transform.matrix3.x_axis
+    }
+
+    pub fn y_dir(&self) -> DVec3 {
+        self.transform.matrix3.y_axis
+    }
+
+    // TODO(bschwind) - Test this.
+    pub fn set_rotation(&mut self, (rot_x, rot_y, rot_z): (Angle, Angle, Angle)) {
+        let rotation_matrix =
+            DMat3::from_euler(EulerRot::XYZ, rot_x.radians(), rot_y.radians(), rot_z.radians());
+
+        let translation = self.transform.translation;
+
+        let x_dir = DVec3::X;
+        let normal_dir = DVec3::Z;
+
+        self.transform = Plane::Custom {
+            x_dir: rotation_matrix.mul_vec3(x_dir).into(),
+            normal_dir: rotation_matrix.mul_vec3(normal_dir).into(),
+        }
+        .transform();
+
+        self.set_translation(translation);
+    }
+
+    pub fn rotate_by(&mut self, (rot_x, rot_y, rot_z): (Angle, Angle, Angle)) {
+        let rotation_matrix =
+            DMat3::from_euler(EulerRot::XYZ, rot_x.radians(), rot_y.radians(), rot_z.radians());
+
+        let translation = self.transform.translation;
+
+        let x_dir = rotation_matrix.mul_vec3(DVec3::X);
+        let normal_dir = rotation_matrix.mul_vec3(DVec3::Z);
+
+        self.transform = Plane::Custom {
+            x_dir: self.transform.transform_vector3(x_dir).into(),
+            normal_dir: self.transform.transform_vector3(normal_dir).into(),
+        }
+        .transform();
+
+        self.set_translation(translation);
+    }
+
+    pub fn set_translation(&mut self, pos: DVec3) {
+        self.transform.translation = pos;
+    }
+
+    pub fn translate_by(&mut self, offset: DVec3) {
+        self.transform.translation += offset;
+    }
+
+    pub fn transformed(&self, offset: DVec3, rotate: RVec) -> Self {
+        let mut new = self.clone();
+        let new_origin = new.to_world_pos(offset);
+
+        new.rotate_by((rotate.x, rotate.y, rotate.z));
+        new.transform.translation = new_origin;
+
+        new
+    }
+
+    pub fn translated(&self, offset: DVec3) -> Self {
+        let mut new = self.clone();
+        let new_origin = new.to_world_pos(offset);
+        new.transform.translation = new_origin;
+
+        new
+    }
+
+    pub fn rotated(&self, rotate: RVec) -> Self {
+        let mut new = self.clone();
+        new.rotate_by((rotate.x, rotate.y, rotate.z));
+
+        new
+    }
+
+    pub fn to_world_pos(&self, pos: DVec3) -> DVec3 {
+        self.transform.transform_point3(pos)
+    }
+
+    pub fn to_local_pos(&self, pos: DVec3) -> DVec3 {
+        self.transform.inverse().transform_point3(pos)
+    }
+
+    pub fn rect(&self, width: f64, height: f64) -> Wire {
+        let half_width = width / 2.0;
+        let half_height = height / 2.0;
+
+        let p1 = self.to_world_pos(dvec3(-half_width, half_height, 0.0));
+        let p2 = self.to_world_pos(dvec3(half_width, half_height, 0.0));
+        let p3 = self.to_world_pos(dvec3(half_width, -half_height, 0.0));
+        let p4 = self.to_world_pos(dvec3(-half_width, -half_height, 0.0));
+
+        let top = Edge::segment(p1, p2);
+        let right = Edge::segment(p2, p3);
+        let bottom = Edge::segment(p3, p4);
+        let left = Edge::segment(p4, p1);
+
+        Wire::from_edges([&top, &right, &bottom, &left])
+    }
+}

--- a/crates/model-api/wit/model-api.wit
+++ b/crates/model-api/wit/model-api.wit
@@ -1,27 +1,32 @@
 package example:host;
 
 world model-world {
+  import print: func(msg: string);
+
   record point3 {
     x: f64,
     y: f64,
     z: f64,
   }
 
-  // resource wire-builder {
-  //   constructor();
-  //   add-edge: func(edge: u64);
-  //   build: func() -> u64;
-  // }
+  resource wasm-wire-builder {
+    constructor();
+    add-edge: func(edge: borrow<wasm-edge>);
+    build: func() -> wasm-wire;
+  }
 
-  // WireBuilder
-  import new-wire-builder: func() -> u64;
-  import wire-builder-add-edge: func(builder: u64, edge: u64);
-  import wire-builder-build: func(builder: u64) -> u64;
+  resource wasm-wire {
 
-  import print: func(msg: string);
+  }
 
-  import new-line-segment: func(p1: point3, p2: point3) -> u64;
+  resource wasm-edge {
+    segment: static func(p1: point3, p2: point3) -> wasm-edge;
+  }
+
+  resource wasm-shape {
+    from-wire: static func(w: borrow<wasm-wire>) -> wasm-shape;
+  }
 
   export init-model: func();
-  export run: func();
+  export run: func() -> wasm-shape;
 }

--- a/crates/model-api/wit/model-api.wit
+++ b/crates/model-api/wit/model-api.wit
@@ -1,0 +1,27 @@
+package example:host;
+
+world model-world {
+  record point3 {
+    x: f64,
+    y: f64,
+    z: f64,
+  }
+
+  // resource wire-builder {
+  //   constructor();
+  //   add-edge: func(edge: u64);
+  //   build: func() -> u64;
+  // }
+
+  // WireBuilder
+  import new-wire-builder: func() -> u64;
+  import wire-builder-add-edge: func(builder: u64, edge: u64);
+  import wire-builder-build: func(builder: u64) -> u64;
+
+  import print: func(msg: string);
+
+  import new-line-segment: func(p1: point3, p2: point3) -> u64;
+
+  export init-model: func();
+  export run: func();
+}

--- a/crates/model-api/wit/model-api.wit
+++ b/crates/model-api/wit/model-api.wit
@@ -9,6 +9,16 @@ world model-world {
     z: f64,
   }
 
+  resource edge-iterator {
+    constructor(face: borrow<face>);
+    next: func() -> option<edge>;
+  }
+
+  resource face-iterator {
+    constructor(shape: borrow<shape>);
+    next: func() -> option<face>;
+  }
+
   resource wire-builder {
     constructor();
     add-edge: func(edge: borrow<edge>);
@@ -22,7 +32,9 @@ world model-world {
   resource face {
     from-wire: static func(w: borrow<wire>) -> face;
     fillet: func(radius: f64) -> face;
+    extrude: func(dir: point3) -> solid;
     outer-wire: func() -> wire;
+    center-of-mass: func() -> point3;
   }
 
   resource shell {
@@ -42,7 +54,12 @@ world model-world {
   }
 
   resource shape {
+    from-edge: static func(w: borrow<edge>) -> shape;
     from-wire: static func(w: borrow<wire>) -> shape;
+    from-face: static func(w: borrow<face>) -> shape;
+    from-shell: static func(w: borrow<shell>) -> shape;
+    from-solid: static func(w: borrow<solid>) -> shape;
+    from-compound: static func(w: borrow<compound>) -> shape;
   }
 
   export init-model: func();

--- a/crates/model-api/wit/model-api.wit
+++ b/crates/model-api/wit/model-api.wit
@@ -19,6 +19,12 @@ world model-world {
     next: func() -> option<face>;
   }
 
+  resource chamfer-maker {
+    constructor(shape: borrow<shape>);
+    add-edge: func(distance: f64, edge: borrow<edge>);
+    build: func() -> shape;
+  }
+
   resource wire-builder {
     constructor();
     add-edge: func(edge: borrow<edge>);

--- a/crates/model-api/wit/model-api.wit
+++ b/crates/model-api/wit/model-api.wit
@@ -9,42 +9,42 @@ world model-world {
     z: f64,
   }
 
-  resource wasm-wire-builder {
+  resource wire-builder {
     constructor();
-    add-edge: func(edge: borrow<wasm-edge>);
-    build: func() -> wasm-wire;
+    add-edge: func(edge: borrow<edge>);
+    build: func() -> wire;
   }
 
-  resource wasm-wire {
-
-  }
-
-  resource wasm-face {
-    from-wire: static func(w: borrow<wasm-wire>) -> wasm-face;
-    fillet: func(radius: f64) -> wasm-face;
-    outer-wire: func() -> wasm-wire;
-  }
-
-  resource wasm-shell {
+  resource wire {
 
   }
 
-  resource wasm-solid {
+  resource face {
+    from-wire: static func(w: borrow<wire>) -> face;
+    fillet: func(radius: f64) -> face;
+    outer-wire: func() -> wire;
+  }
+
+  resource shell {
 
   }
 
-  resource wasm-compound {
+  resource solid {
 
   }
 
-  resource wasm-edge {
-    segment: static func(p1: point3, p2: point3) -> wasm-edge;
+  resource compound {
+
   }
 
-  resource wasm-shape {
-    from-wire: static func(w: borrow<wasm-wire>) -> wasm-shape;
+  resource edge {
+    segment: static func(p1: point3, p2: point3) -> edge;
+  }
+
+  resource shape {
+    from-wire: static func(w: borrow<wire>) -> shape;
   }
 
   export init-model: func();
-  export run: func() -> wasm-shape;
+  export run: func() -> shape;
 }

--- a/crates/model-api/wit/model-api.wit
+++ b/crates/model-api/wit/model-api.wit
@@ -19,6 +19,22 @@ world model-world {
 
   }
 
+  resource wasm-face {
+
+  }
+
+  resource wasm-shell {
+
+  }
+
+  resource wasm-solid {
+
+  }
+
+  resource wasm-compound {
+
+  }
+
   resource wasm-edge {
     segment: static func(p1: point3, p2: point3) -> wasm-edge;
   }

--- a/crates/model-api/wit/model-api.wit
+++ b/crates/model-api/wit/model-api.wit
@@ -20,7 +20,9 @@ world model-world {
   }
 
   resource wasm-face {
-
+    from-wire: static func(w: borrow<wasm-wire>) -> wasm-face;
+    fillet: func(radius: f64) -> wasm-face;
+    outer-wire: func() -> wasm-wire;
   }
 
   resource wasm-shell {

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1220,3 +1220,9 @@ pub mod ffi {
         );
     }
 }
+
+// Gross, but is this okay?
+unsafe impl Send for ffi::BRepBuilderAPI_MakeWire {}
+unsafe impl Send for ffi::TopoDS_Edge {}
+unsafe impl Send for ffi::TopoDS_Wire {}
+unsafe impl Send for ffi::TopoDS_Shape {}

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1230,3 +1230,5 @@ unsafe impl Send for ffi::TopoDS_Shell {}
 unsafe impl Send for ffi::TopoDS_Solid {}
 unsafe impl Send for ffi::TopoDS_Compound {}
 unsafe impl Send for ffi::TopoDS_Shape {}
+
+unsafe impl Send for ffi::TopExp_Explorer {}

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1225,4 +1225,8 @@ pub mod ffi {
 unsafe impl Send for ffi::BRepBuilderAPI_MakeWire {}
 unsafe impl Send for ffi::TopoDS_Edge {}
 unsafe impl Send for ffi::TopoDS_Wire {}
+unsafe impl Send for ffi::TopoDS_Face {}
+unsafe impl Send for ffi::TopoDS_Shell {}
+unsafe impl Send for ffi::TopoDS_Solid {}
+unsafe impl Send for ffi::TopoDS_Compound {}
 unsafe impl Send for ffi::TopoDS_Shape {}

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1232,3 +1232,4 @@ unsafe impl Send for ffi::TopoDS_Compound {}
 unsafe impl Send for ffi::TopoDS_Shape {}
 
 unsafe impl Send for ffi::TopExp_Explorer {}
+unsafe impl Send for ffi::BRepFilletAPI_MakeChamfer {}

--- a/crates/opencascade/src/primitives/face.rs
+++ b/crates/opencascade/src/primitives/face.rs
@@ -299,6 +299,13 @@ impl Face {
     pub fn orientation(&self) -> FaceOrientation {
         FaceOrientation::from(self.inner.Orientation())
     }
+
+    #[must_use]
+    pub fn outer_wire(&self) -> Wire {
+        let inner = ffi::outer_wire(&self.inner);
+
+        Wire { inner }
+    }
 }
 
 pub struct CompoundFace {

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -698,3 +698,23 @@ pub struct LineFaceHitPoint {
     /// The intersection point
     pub point: DVec3,
 }
+
+pub struct ChamferMaker {
+    inner: UniquePtr<ffi::BRepFilletAPI_MakeChamfer>,
+}
+
+impl ChamferMaker {
+    pub fn new(shape: &Shape) -> Self {
+        let make_chamfer = ffi::BRepFilletAPI_MakeChamfer_ctor(&shape.inner);
+
+        Self { inner: make_chamfer }
+    }
+
+    pub fn add_edge(&mut self, distance: f64, edge: &Edge) {
+        self.inner.pin_mut().add_edge(distance, &edge.inner);
+    }
+
+    pub fn build(mut self) -> Shape {
+        Shape::from_shape(self.inner.pin_mut().Shape())
+    }
+}

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -29,8 +29,24 @@ impl From<Vertex> for Shape {
     }
 }
 
+impl From<&Vertex> for Shape {
+    fn from(vertex: &Vertex) -> Self {
+        let shape = ffi::cast_vertex_to_shape(&vertex.inner);
+
+        Self::from_shape(shape)
+    }
+}
+
 impl From<Edge> for Shape {
     fn from(edge: Edge) -> Self {
+        let shape = ffi::cast_edge_to_shape(&edge.inner);
+
+        Self::from_shape(shape)
+    }
+}
+
+impl From<&Edge> for Shape {
+    fn from(edge: &Edge) -> Self {
         let shape = ffi::cast_edge_to_shape(&edge.inner);
 
         Self::from_shape(shape)
@@ -45,8 +61,24 @@ impl From<Wire> for Shape {
     }
 }
 
+impl From<&Wire> for Shape {
+    fn from(wire: &Wire) -> Self {
+        let shape = ffi::cast_wire_to_shape(&wire.inner);
+
+        Self::from_shape(shape)
+    }
+}
+
 impl From<Face> for Shape {
     fn from(face: Face) -> Self {
+        let shape = ffi::cast_face_to_shape(&face.inner);
+
+        Self::from_shape(shape)
+    }
+}
+
+impl From<&Face> for Shape {
+    fn from(face: &Face) -> Self {
         let shape = ffi::cast_face_to_shape(&face.inner);
 
         Self::from_shape(shape)
@@ -61,6 +93,14 @@ impl From<Shell> for Shape {
     }
 }
 
+impl From<&Shell> for Shape {
+    fn from(shell: &Shell) -> Self {
+        let shape = ffi::cast_shell_to_shape(&shell.inner);
+
+        Self::from_shape(shape)
+    }
+}
+
 impl From<Solid> for Shape {
     fn from(solid: Solid) -> Self {
         let shape = ffi::cast_solid_to_shape(&solid.inner);
@@ -69,8 +109,24 @@ impl From<Solid> for Shape {
     }
 }
 
+impl From<&Solid> for Shape {
+    fn from(solid: &Solid) -> Self {
+        let shape = ffi::cast_solid_to_shape(&solid.inner);
+
+        Self::from_shape(shape)
+    }
+}
+
 impl From<Compound> for Shape {
     fn from(compound: Compound) -> Self {
+        let shape = ffi::cast_compound_to_shape(&compound.inner);
+
+        Self::from_shape(shape)
+    }
+}
+
+impl From<&Compound> for Shape {
+    fn from(compound: &Compound) -> Self {
         let shape = ffi::cast_compound_to_shape(&compound.inner);
 
         Self::from_shape(shape)

--- a/crates/opencascade/src/primitives/wire.rs
+++ b/crates/opencascade/src/primitives/wire.rs
@@ -239,3 +239,29 @@ impl Wire {
     // Create a closure-based API
     pub fn freeform() {}
 }
+
+pub struct WireBuilder {
+    inner: UniquePtr<ffi::BRepBuilderAPI_MakeWire>,
+}
+
+impl Default for WireBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WireBuilder {
+    pub fn new() -> Self {
+        let make_wire = ffi::BRepBuilderAPI_MakeWire_ctor();
+
+        Self { inner: make_wire }
+    }
+
+    pub fn add_edge(&mut self, edge: &Edge) {
+        self.inner.pin_mut().add_edge(&edge.inner);
+    }
+
+    pub fn build(self) -> Wire {
+        Wire::from_make_wire(self.inner)
+    }
+}

--- a/crates/viewer/Cargo.toml
+++ b/crates/viewer/Cargo.toml
@@ -16,6 +16,7 @@ smaa = "0.12"
 wasmtime = "20"
 wgpu = "0.18"
 winit = { version = "0.29", features = ["rwh_05"] }
+wit-component = { version = "0.209", default-features = false }
 
 [build-dependencies]
 naga = { version = "0.14", features = ["validate", "wgsl-in"] }

--- a/crates/viewer/Cargo.toml
+++ b/crates/viewer/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "4", features = ["derive"] }
 examples = { path = "../../examples", default-features = false }
 glam = { version = "0.24", features = ["bytemuck"] }
 kicad-parser = { path = "../kicad-parser" }
+notify = "6"
 opencascade = { version = "0.2", path = "../opencascade", default-features = false }
 simple-game = { git = "https://github.com/bschwind/simple-game.git", rev = "651a57a9f28b0707afbb5a43fe1cbc8f6755169c", default-features = false }
 smaa = "0.12"

--- a/crates/viewer/Cargo.toml
+++ b/crates/viewer/Cargo.toml
@@ -13,6 +13,7 @@ kicad-parser = { path = "../kicad-parser" }
 opencascade = { version = "0.2", path = "../opencascade", default-features = false }
 simple-game = { git = "https://github.com/bschwind/simple-game.git", rev = "651a57a9f28b0707afbb5a43fe1cbc8f6755169c", default-features = false }
 smaa = "0.12"
+wasmtime = "20"
 wgpu = "0.18"
 winit = { version = "0.29", features = ["rwh_05"] }
 

--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -1,6 +1,7 @@
 use crate::{
     edge_drawer::{EdgeDrawer, LineBuilder, LineVertex3, RenderedLine},
     surface_drawer::{CadMesh, SurfaceDrawer},
+    wasm_engine::WasmEngine,
 };
 use anyhow::Error;
 use camera::OrbitCamera;
@@ -32,6 +33,7 @@ use winit::{
 mod camera;
 mod edge_drawer;
 mod surface_drawer;
+mod wasm_engine;
 
 // Multipliers to convert mouse position deltas to a more intuitve camera perspective change.
 const ZOOM_MULTIPLIER: f32 = 5.0;
@@ -78,6 +80,7 @@ struct ViewerApp {
     rendered_edges: RenderedLine,
     cad_mesh: CadMesh,
     mouse_state: MouseState,
+    // wasm_engine: WasmEngine,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -116,7 +119,11 @@ impl GameApp for ViewerApp {
             example.shape()
         } else {
             eprintln!("Warning - no example or STEP file specified, you get a default cube.");
-            Shape::cube_centered(50.0)
+
+            let wasm_engine = WasmEngine::new();
+            wasm_engine.shape()
+
+            // Shape::cube_centered(50.0)
         };
 
         let mesh = shape.mesh().expect("example shape should yield a valid triangulation");
@@ -187,6 +194,7 @@ impl GameApp for ViewerApp {
             cad_mesh,
             rendered_edges,
             mouse_state: Default::default(),
+            // wasm_engine,
         }
     }
 

--- a/crates/viewer/src/wasm_engine.rs
+++ b/crates/viewer/src/wasm_engine.rs
@@ -1,5 +1,5 @@
 use glam::DVec3;
-use opencascade::primitives::{Edge, Face, Shape, Wire, WireBuilder};
+use opencascade::primitives::{Compound, Edge, Face, Shape, Shell, Solid, Wire, WireBuilder};
 use wasmtime::{
     component::{Component, Linker, Resource, ResourceTable},
     Config, Engine, Store,
@@ -11,6 +11,10 @@ wasmtime::component::bindgen!({
         "wasm-wire-builder": MyWireBuilder,
         "wasm-edge": MyEdge,
         "wasm-wire": MyWire,
+        "wasm-face": MyFace,
+        "wasm-shell": MyShell,
+        "wasm-solid": MySolid,
+        "wasm-compound": MyCompound,
         "wasm-shape": MyShape,
     },
 });
@@ -27,6 +31,22 @@ pub struct MyWire {
     wire: Wire,
 }
 
+pub struct MyFace {
+    face: Face,
+}
+
+pub struct MyShell {
+    shell: Shell,
+}
+
+pub struct MySolid {
+    shell: Solid,
+}
+
+pub struct MyCompound {
+    compound: Compound,
+}
+
 pub struct MyShape {
     shape: Shape,
 }
@@ -41,6 +61,10 @@ struct ModelHost {
     wire_builders: ResourceTable,
     edges: ResourceTable,
     wires: ResourceTable,
+    faces: ResourceTable,
+    shells: ResourceTable,
+    solids: ResourceTable,
+    compounds: ResourceTable,
     shapes: ResourceTable,
 }
 
@@ -50,6 +74,10 @@ impl ModelHost {
             wire_builders: ResourceTable::new(),
             edges: ResourceTable::new(),
             wires: ResourceTable::new(),
+            faces: ResourceTable::new(),
+            shells: ResourceTable::new(),
+            solids: ResourceTable::new(),
+            compounds: ResourceTable::new(),
             shapes: ResourceTable::new(),
         }
     }
@@ -103,6 +131,34 @@ impl HostWasmWireBuilder for ModelHost {
 impl HostWasmWire for ModelHost {
     fn drop(&mut self, resource: Resource<MyWire>) -> Result<(), anyhow::Error> {
         let _ = self.wires.delete(resource);
+        Ok(())
+    }
+}
+
+impl HostWasmFace for ModelHost {
+    fn drop(&mut self, resource: Resource<MyFace>) -> Result<(), anyhow::Error> {
+        let _ = self.faces.delete(resource);
+        Ok(())
+    }
+}
+
+impl HostWasmShell for ModelHost {
+    fn drop(&mut self, resource: Resource<MyShell>) -> Result<(), anyhow::Error> {
+        let _ = self.shells.delete(resource);
+        Ok(())
+    }
+}
+
+impl HostWasmSolid for ModelHost {
+    fn drop(&mut self, resource: Resource<MySolid>) -> Result<(), anyhow::Error> {
+        let _ = self.solids.delete(resource);
+        Ok(())
+    }
+}
+
+impl HostWasmCompound for ModelHost {
+    fn drop(&mut self, resource: Resource<MyCompound>) -> Result<(), anyhow::Error> {
+        let _ = self.compounds.delete(resource);
         Ok(())
     }
 }

--- a/crates/viewer/src/wasm_engine.rs
+++ b/crates/viewer/src/wasm_engine.rs
@@ -158,7 +158,7 @@ impl HostChamferMaker for ModelHost {
     }
 
     fn drop(&mut self, resource: Resource<occ::ChamferMaker>) -> Result<(), anyhow::Error> {
-        let _ = self.face_iterators.delete(resource);
+        let _ = self.chamfer_makers.delete(resource);
         Ok(())
     }
 }
@@ -169,7 +169,7 @@ impl HostEdge for ModelHost {
     }
 
     fn drop(&mut self, resource: Resource<occ::Edge>) -> Result<(), anyhow::Error> {
-        let _ = self.wire_builders.delete(resource);
+        let _ = self.edges.delete(resource);
         Ok(())
     }
 }
@@ -294,7 +294,7 @@ impl HostCompound for ModelHost {
 
 impl HostShape for ModelHost {
     fn drop(&mut self, resource: Resource<occ::Shape>) -> Result<(), anyhow::Error> {
-        let _ = self.wires.delete(resource);
+        let _ = self.shapes.delete(resource);
         Ok(())
     }
 

--- a/crates/viewer/src/wasm_engine.rs
+++ b/crates/viewer/src/wasm_engine.rs
@@ -13,6 +13,9 @@ use wasmtime::{
 
 wasmtime::component::bindgen!({
     path: "../model-api/wit",
+    // This is where we map the types we declared in the WIT file
+    // to their corresponding host type, which will be managed as
+    // a wasmtime "Resource".
     with: {
         "wire-builder": occ::WireBuilder,
         "edge-iterator": occ::EdgeIterator,

--- a/crates/viewer/src/wasm_engine.rs
+++ b/crates/viewer/src/wasm_engine.rs
@@ -140,6 +140,37 @@ impl HostWasmFace for ModelHost {
         let _ = self.faces.delete(resource);
         Ok(())
     }
+
+    fn fillet(
+        &mut self,
+        face_resource: Resource<MyFace>,
+        radius: f64,
+    ) -> Result<Resource<MyFace>, anyhow::Error> {
+        let face = self.faces.get(&face_resource)?;
+        let new_face = face.face.fillet(radius);
+        Ok(self.faces.push(MyFace { face: new_face })?)
+    }
+
+    fn from_wire(
+        &mut self,
+        wire_resource: Resource<MyWire>,
+    ) -> Result<Resource<MyFace>, anyhow::Error> {
+        let wire = self.wires.get(&wire_resource)?;
+        let face = Face::from_wire(&wire.wire);
+
+        let new_face = self.faces.push(MyFace { face })?;
+
+        Ok(new_face)
+    }
+
+    fn outer_wire(
+        &mut self,
+        face_resource: Resource<MyFace>,
+    ) -> Result<Resource<MyWire>, anyhow::Error> {
+        let face = self.faces.get(&face_resource)?;
+        let new_wire = face.face.outer_wire();
+        Ok(self.wires.push(MyWire { wire: new_wire })?)
+    }
 }
 
 impl HostWasmShell for ModelHost {

--- a/crates/viewer/src/wasm_engine.rs
+++ b/crates/viewer/src/wasm_engine.rs
@@ -1,0 +1,103 @@
+use glam::DVec3;
+use opencascade::primitives::{Edge, Shape, Wire, WireBuilder};
+use wasmtime::{
+    component::{bindgen, Component, Linker},
+    Config, Engine, Store,
+};
+
+bindgen!("model-world" in "../model-api/wit");
+
+impl From<Point3> for DVec3 {
+    fn from(p: Point3) -> Self {
+        Self { x: p.x, y: p.y, z: p.z }
+    }
+}
+
+struct ModelHost {
+    edges: Vec<Edge>,
+    wires: Vec<Wire>,
+    wire_builders: Vec<WireBuilder>,
+}
+
+impl ModelHost {
+    fn new() -> Self {
+        Self { edges: Vec::new(), wires: Vec::new(), wire_builders: Vec::new() }
+    }
+}
+
+// Imports into the world, like the `name` import for this world, are
+// satisfied through traits.
+impl ModelWorldImports for ModelHost {
+    fn print(&mut self, _msg: String) -> Result<(), wasmtime::Error> {
+        Ok(())
+    }
+
+    fn new_line_segment(&mut self, p1: Point3, p2: Point3) -> Result<u64, anyhow::Error> {
+        let edge_id = self.edges.len();
+        self.edges.push(Edge::segment(p1.into(), p2.into()));
+
+        Ok(edge_id as u64)
+    }
+
+    fn new_wire_builder(&mut self) -> Result<u64, anyhow::Error> {
+        let builder_id = self.wire_builders.len();
+        self.wire_builders.push(WireBuilder::new());
+
+        Ok(builder_id as u64)
+    }
+
+    fn wire_builder_add_edge(
+        &mut self,
+        builder_id: u64,
+        edge_id: u64,
+    ) -> Result<(), anyhow::Error> {
+        let builder = &mut self.wire_builders[builder_id as usize];
+        builder.add_edge(&self.edges[edge_id as usize]);
+        Ok(())
+    }
+
+    fn wire_builder_build(&mut self, builder_id: u64) -> Result<u64, anyhow::Error> {
+        let builder = self.wire_builders.remove(builder_id as usize);
+        let wire = builder.build();
+
+        let wire_id = self.wires.len();
+        self.wires.push(wire);
+        Ok(wire_id as u64)
+    }
+}
+
+pub struct WasmEngine {
+    engine: Engine,
+    linker: Linker<ModelHost>,
+    component: Component,
+}
+
+impl WasmEngine {
+    pub fn new() -> Self {
+        let mut config = Config::new();
+        config.wasm_component_model(true);
+        let engine = Engine::new(&config).unwrap();
+
+        let component = Component::from_file(&engine, "./my-component.wasm").unwrap();
+
+        let mut linker = Linker::new(&engine);
+        ModelWorld::add_to_linker(&mut linker, |state: &mut ModelHost| state).unwrap();
+
+        Self { engine, linker, component }
+    }
+
+    pub fn shape(&self) -> Shape {
+        let mut store = Store::new(&self.engine, ModelHost::new());
+
+        let (bindings, _) =
+            ModelWorld::instantiate(&mut store, &self.component, &self.linker).unwrap();
+
+        bindings.call_init_model(&mut store).unwrap();
+        bindings.call_run(&mut store).unwrap();
+
+        let mut data = store.into_data();
+        let last_wire = data.wires.remove(data.wires.len() - 1);
+
+        last_wire.to_face().into()
+    }
+}

--- a/crates/wasm-example/Cargo.toml
+++ b/crates/wasm-example/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+glam = { version = "0.24" }
 model-api = { path = "../model-api" }
 
 [lib]

--- a/crates/wasm-example/Cargo.toml
+++ b/crates/wasm-example/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wasm-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+model-api = { path = "../model-api" }
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/wasm-example/README.md
+++ b/crates/wasm-example/README.md
@@ -2,7 +2,7 @@
 
 An example of model code which can be compiled to WASM and executed in the viewer app.
 
-Use [cargo watch]() to listen for file changes and rebuild the model file whenever code is edited:
+Use [cargo watch](https://crates.io/crates/cargo-watch) to listen for file changes and rebuild the model file whenever code is edited:
 
 ```
 $ cargo watch -x "build -p wasm-example --release --target wasm32-unknown-unknown"

--- a/crates/wasm-example/README.md
+++ b/crates/wasm-example/README.md
@@ -1,0 +1,15 @@
+# wasm-example
+
+An example of model code which can be compiled to WASM and executed in the viewer app.
+
+Use [cargo watch]() to listen for file changes and rebuild the model file whenever code is edited:
+
+```
+$ cargo watch -x "build -p wasm-example --release --target wasm32-unknown-unknown"
+```
+
+Run the viewer app with:
+
+```
+$ cargo run --release --no-default-features --bin viewer
+```

--- a/crates/wasm-example/src/lib.rs
+++ b/crates/wasm-example/src/lib.rs
@@ -5,9 +5,9 @@ use model_api::{
     Model,
 };
 
-struct CableBracket {}
+struct RoundedChamfer {}
 
-impl Model for CableBracket {
+impl Model for RoundedChamfer {
     fn new() -> Self {
         Self {}
     }
@@ -15,17 +15,15 @@ impl Model for CableBracket {
     fn create_model(&mut self) -> Shape {
         let shape = Workplane::xy()
             .rect(16.0, 10.0)
-            .fillet(2.0)
+            .fillet(1.0)
             .to_face()
-            .extrude(dvec3(0.0, 0.0, 1.0))
+            .extrude(dvec3(0.0, 0.0, 3.0))
             .into_shape();
 
-        let _top_edges = shape.faces().farthest(Direction::PosZ).edges();
+        let top_edges = shape.faces().farthest(Direction::PosZ).edges();
 
-        // shape.chamfer_edges(0.7, top_edges)
-
-        shape
+        shape.chamfer_edges(0.7, top_edges)
     }
 }
 
-model_api::register_model!(CableBracket);
+model_api::register_model!(RoundedChamfer);

--- a/crates/wasm-example/src/lib.rs
+++ b/crates/wasm-example/src/lib.rs
@@ -1,0 +1,15 @@
+use model_api::{workplane::Workplane, Model};
+
+struct CableBracket {}
+
+impl Model for CableBracket {
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn create_model(&mut self) {
+        let _shape = Workplane::xy().rect(16.0, 10.0);
+    }
+}
+
+model_api::register_model!(CableBracket);

--- a/crates/wasm-example/src/lib.rs
+++ b/crates/wasm-example/src/lib.rs
@@ -8,7 +8,7 @@ impl Model for CableBracket {
     }
 
     fn create_model(&mut self) -> Shape {
-        let wire = Workplane::xy().rect(16.0, 10.0);
+        let wire = Workplane::xy().rect(16.0, 10.0).fillet(1.0);
         Shape::from_wire(&wire)
     }
 }

--- a/crates/wasm-example/src/lib.rs
+++ b/crates/wasm-example/src/lib.rs
@@ -1,4 +1,9 @@
-use model_api::{primitives::Shape, workplane::Workplane, Model};
+use glam::dvec3;
+use model_api::{
+    primitives::{Direction, IntoShape, Shape},
+    workplane::Workplane,
+    Model,
+};
 
 struct CableBracket {}
 
@@ -8,8 +13,18 @@ impl Model for CableBracket {
     }
 
     fn create_model(&mut self) -> Shape {
-        let wire = Workplane::xy().rect(16.0, 10.0).fillet(1.0);
-        Shape::from_wire(&wire)
+        let shape = Workplane::xy()
+            .rect(16.0, 10.0)
+            .fillet(2.0)
+            .to_face()
+            .extrude(dvec3(0.0, 0.0, 1.0))
+            .into_shape();
+
+        let _top_edges = shape.faces().farthest(Direction::PosZ).edges();
+
+        // shape.chamfer_edges(0.7, top_edges)
+
+        shape
     }
 }
 

--- a/crates/wasm-example/src/lib.rs
+++ b/crates/wasm-example/src/lib.rs
@@ -1,4 +1,4 @@
-use model_api::{workplane::Workplane, Model};
+use model_api::{primitives::Shape, workplane::Workplane, Model};
 
 struct CableBracket {}
 
@@ -7,8 +7,9 @@ impl Model for CableBracket {
         Self {}
     }
 
-    fn create_model(&mut self) {
-        let _shape = Workplane::xy().rect(16.0, 10.0);
+    fn create_model(&mut self) -> Shape {
+        let wire = Workplane::xy().rect(16.0, 10.0);
+        Shape::from_wire(&wire)
     }
 }
 

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,0 @@
-cargo build -p wasm-example --release --target wasm32-unknown-unknown
-# wasm-tools component new ./target/wasm32-unknown-unknown/release/wasm_example.wasm -o my-component.wasm
-cargo run --release --no-default-features --bin viewer

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,3 @@
-cd crates/wasm-example
 cargo build -p wasm-example --release --target wasm32-unknown-unknown
-cd ../..
-wasm-tools component new ./target/wasm32-unknown-unknown/release/wasm_example.wasm -o my-component.wasm
+# wasm-tools component new ./target/wasm32-unknown-unknown/release/wasm_example.wasm -o my-component.wasm
 cargo run --release --no-default-features --bin viewer

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+cd crates/wasm-example
+cargo build -p wasm-example --release --target wasm32-unknown-unknown
+cd ../..
+wasm-tools component new ./target/wasm32-unknown-unknown/release/wasm_example.wasm -o my-component.wasm
+cargo run --release --no-default-features --bin viewer


### PR DESCRIPTION
Starts #67

Supersedes #123

TODO

- [x] Fix all clippy warnings/errors
- [x] Use the `wit-component` crate to [convert the wasm bundle to a wasm component](https://github.com/bytecodealliance/wasmtime/blob/28ee78b654e45cfa5837857d7880d8c40d571cb4/examples/component/main.rs#L32-L37)
- [x] Have live-reloading WASM files
- [x] Log model errors in the viewer app instead of crashing
- [x] Migrate some more modeling API functions to at least be able to create some interesting solids and shapes
- [ ] (nice to have) - Figure out auto-formatting for WIT files