### PR TITLE
update occt sys to 0.6

### DIFF
--- a/crates/opencascade-sys/Cargo.toml
+++ b/crates/opencascade-sys/Cargo.toml
@@ -13,7 +13,7 @@ cxx = "1"
 [build-dependencies]
 cmake = "0.1"
 cxx-build = "1"
-occt-sys = { version = "0.5.1", optional = true }
+occt-sys = { version = "0.6", optional = true }
 
 [features]
 builtin = ["occt-sys"]

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -88,6 +88,7 @@ impl OcctConfig {
         // Add path to builtin OCCT
         #[cfg(feature = "builtin")]
         {
+            occt_sys::build_occt();
             std::env::set_var("DEP_OCCT_ROOT", occt_sys::occt_path().as_os_str());
         }
 


### PR DESCRIPTION
follow up to https://github.com/bschwind/opencascade-rs/pull/185 updating occt sys reference to the patched 0.6 version, as discussed in #185