### PR TITLE
Reduce Render Passes

### DIFF
--- a/crates/viewer/Cargo.toml
+++ b/crates/viewer/Cargo.toml
@@ -12,7 +12,7 @@ glam = { version = "0.24", features = ["bytemuck"] }
 kicad-parser = { path = "../kicad-parser" }
 notify = "6"
 opencascade = { version = "0.2", path = "../opencascade", default-features = false }
-simple-game = { git = "https://github.com/bschwind/simple-game.git", rev = "14851f657e523ba31f1a677a3e5ae2291e1f2b21" }
+simple-game = { git = "https://github.com/bschwind/simple-game.git", rev = "19f800cf5c29a41e44caaab2baf62b5cbddb5ce2" }
 smaa = "0.16"
 wasmtime = "20"
 wgpu = "24"

--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -370,6 +370,7 @@ impl GameApp for ViewerApp {
 
         drop(render_pass);
 
+        // TODO(bschwind) - Pass in the render_pass to the text_system too.
         self.text_system.render_horizontal(
             TextAlignment {
                 x: AxisAlign::Start(10),

--- a/crates/viewer/src/main.rs
+++ b/crates/viewer/src/main.rs
@@ -196,7 +196,13 @@ impl GameApp for ViewerApp {
             client_rect: vec2(width as f32, height as f32),
             camera: OrbitCamera::new(width, height, Vec3::new(40.0, -40.0, 20.0)),
             depth_texture,
-            text_system: TextSystem::new(device, surface_texture_format, width, height),
+            text_system: TextSystem::new(
+                device,
+                surface_texture_format,
+                Some(depth_texture_format),
+                width,
+                height,
+            ),
             fps_counter: FPSCounter::new(),
             line_drawer: EdgeDrawer::new(
                 device,
@@ -368,9 +374,6 @@ impl GameApp for ViewerApp {
             gap_size,
         );
 
-        drop(render_pass);
-
-        // TODO(bschwind) - Pass in the render_pass to the text_system too.
         self.text_system.render_horizontal(
             TextAlignment {
                 x: AxisAlign::Start(10),
@@ -379,10 +382,11 @@ impl GameApp for ViewerApp {
                 max_height: None,
             },
             &[StyledText::default_styling(&format!("FPS: {}", self.fps_counter.fps()))],
-            &mut frame_encoder.encoder,
-            &smaa_render_target,
+            &mut render_pass,
             graphics_device.queue(),
         );
+
+        drop(render_pass);
 
         graphics_device.queue().submit(Some(frame_encoder.encoder.finish()));
 

--- a/crates/viewer/src/surface_drawer.rs
+++ b/crates/viewer/src/surface_drawer.rs
@@ -122,9 +122,7 @@ impl SurfaceDrawer {
     #[allow(clippy::too_many_arguments)]
     pub fn render(
         &self,
-        encoder: &mut wgpu::CommandEncoder,
-        render_target: &wgpu::TextureView,
-        depth_view: &wgpu::TextureView,
+        render_pass: &mut wgpu::RenderPass,
         queue: &wgpu::Queue,
         cad_mesh: &CadMesh,
         camera_matrix: Mat4,
@@ -133,28 +131,6 @@ impl SurfaceDrawer {
         let uniforms = CadMeshUniforms { proj: camera_matrix, transform };
 
         queue.write_buffer(&self.vertex_uniform, 0, bytemuck::bytes_of(&uniforms));
-
-        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: Some("CadMesh render pass"),
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: render_target,
-                resolve_target: None,
-                ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(wgpu::Color { r: 0.3, g: 0.3, b: 0.3, a: 1.0 }),
-                    store: wgpu::StoreOp::Store,
-                },
-            })],
-            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                view: depth_view,
-                depth_ops: Some(wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(1.0),
-                    store: wgpu::StoreOp::Store,
-                }),
-                stencil_ops: None,
-            }),
-            occlusion_query_set: None,
-            timestamp_writes: None,
-        });
 
         render_pass.set_pipeline(&self.pipeline);
         render_pass.set_bind_group(0, &self.uniform_bind_group, &[]);


### PR DESCRIPTION
Following the recommendation from the [WGPU Wiki](https://github.com/gfx-rs/wgpu/wiki/Encapsulating-Graphics-Work), most graphics primitives should not create their own RenderPass but instead accept one when they want to render.