### PR TITLE
Add gp_Dir.Transform to opencascade-sys

### DIFF
--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -948,6 +948,8 @@ pub mod ffi {
         pub fn gp_OZ() -> &'static gp_Ax1;
         pub fn gp_DZ() -> &'static gp_Dir;
 
+        pub fn Transform(self: Pin<&mut gp_Dir>, transform: &gp_Trsf);
+
         pub fn X(self: &gp_Dir) -> f64;
         pub fn Y(self: &gp_Dir) -> f64;
         pub fn Z(self: &gp_Dir) -> f64;


### PR DESCRIPTION
I need this for transforming normals when exporting meshes.

There's analogous methods here on other types, but I thought it best for now to add what I need. In the future should I add related methods simultaneously?