### PR TITLE
Export normals correctly

### DIFF
--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -948,6 +948,8 @@ pub mod ffi {
         pub fn gp_OZ() -> &'static gp_Ax1;
         pub fn gp_DZ() -> &'static gp_Dir;
 
+        pub fn Transform(self: Pin<&mut gp_Dir>, transform: &gp_Trsf);
+
         pub fn X(self: &gp_Dir) -> f64;
         pub fn Y(self: &gp_Dir) -> f64;
         pub fn Z(self: &gp_Dir) -> f64;


### PR DESCRIPTION
Stacked on top of #210

Unfortunately I don't currently have an easy way to test this code - only the corresponding code in anvil (https://github.com/paramatrix-dev/anvil/pull/15)... so while it's probably correct I don't feel confident in asking for it to be merged. In the very near future I'll set up something so I can render meshes from this library as well as anvil at which point I'll move the PR from a draft to a real one (and maybe try and fix up line 93 at the same time... since that looks very suspicious... particularly the part where the only use of `normal_array` is `normal_array.Length()`).