### PR TITLE
Add bounding box support

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -527,6 +527,14 @@ cast_section_to_builderalgo(std::unique_ptr<BRepAlgoAPI_Section> section) {
 
 // Bnd_Box
 inline std::unique_ptr<Bnd_Box> Bnd_Box_ctor() { return std::unique_ptr<Bnd_Box>(new Bnd_Box()); }
+inline std::unique_ptr<gp_Pnt> Bnd_Box_CornerMin(const Bnd_Box &box) {
+  auto p = box.CornerMin();
+  return std::unique_ptr<gp_Pnt>(new gp_Pnt(p));
+}
+inline std::unique_ptr<gp_Pnt> Bnd_Box_CornerMax(const Bnd_Box &box) {
+  auto p = box.CornerMax();
+  return std::unique_ptr<gp_Pnt>(new gp_Pnt(p));
+}
 
 // BRepBndLib
 inline void BRepBndLib_Add(const TopoDS_Shape &shape, Bnd_Box &box, const Standard_Boolean useTriangulation) {

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -5,6 +5,7 @@
 #include <BRepAlgoAPI_Cut.hxx>
 #include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepAlgoAPI_Section.hxx>
+#include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_GTransform.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -527,3 +527,8 @@ cast_section_to_builderalgo(std::unique_ptr<BRepAlgoAPI_Section> section) {
 
 // Bnd_Box
 inline std::unique_ptr<Bnd_Box> Bnd_Box_ctor() { return std::unique_ptr<Bnd_Box>(new Bnd_Box()); }
+
+// BRepBndLib
+inline void BRepBndLib_Add(const TopoDS_Shape &shape, Bnd_Box &box, const Standard_Boolean useTriangulation) {
+  BRepBndLib::Add(shape, box, useTriangulation);
+}

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -524,3 +524,6 @@ cast_section_to_builderalgo(std::unique_ptr<BRepAlgoAPI_Section> section) {
   return section;
 }
 // namespace BRepAlgoAPI
+
+// Bnd_Box
+inline std::unique_ptr<Bnd_Box> Bnd_Box_ctor() { return std::unique_ptr<Bnd_Box>(new Bnd_Box()); }

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1380,6 +1380,20 @@ pub mod ffi {
         // Describes a bounding box in 3D space.
         type Bnd_Box;
 
+        #[cxx_name = "construct_unique"]
+        pub fn Bnd_Box_ctor() -> UniquePtr<Bnd_Box>;
+        pub fn IsVoid(self: &Bnd_Box) -> bool;
+        pub fn Get(
+            self: &Bnd_Box,
+            xMin: &mut f64,
+            yMin: &mut f64,
+            zMin: &mut f64,
+            xMax: &mut f64,
+            yMax: &mut f64,
+            zMax: &mut f64,
+        );
+        pub fn Set(self: Pin<&mut Bnd_Box>, p: &gp_Pnt);
+
         // BRepBndLib
         // Bounding boxes for curves and surfaces.
         type BRepBndLib;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1392,7 +1392,9 @@ pub mod ffi {
             yMax: &mut f64,
             zMax: &mut f64,
         );
+        pub fn GetGap(self: &Bnd_Box) -> f64;
         pub fn Set(self: Pin<&mut Bnd_Box>, p: &gp_Pnt);
+        pub fn SetGap(self: Pin<&mut Bnd_Box>, gap: f64);
 
         // BRepBndLib
         // Bounding boxes for curves and surfaces.

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1376,6 +1376,10 @@ pub mod ffi {
             wires: Pin<&mut HandleTopTools_HSequenceOfShape>,
         );
 
+        // BndBox
+        // Describes a bounding box in 3D space.
+        type Bnd_Box;
+
         // BRepBndLib
         // Bounding boxes for curves and surfaces.
         type BRepBndLib;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1397,6 +1397,8 @@ pub mod ffi {
         // BRepBndLib
         // Bounding boxes for curves and surfaces.
         type BRepBndLib;
+
+        pub fn BRepBndLib_Add(shape: &TopoDS_Shape, bb: Pin<&mut Bnd_Box>, use_triangulation: bool);
     }
 }
 

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1375,6 +1375,10 @@ pub mod ffi {
             shared: bool,
             wires: Pin<&mut HandleTopTools_HSequenceOfShape>,
         );
+
+        // BRepBndLib
+        // Bounding boxes for curves and surfaces.
+        type BRepBndLib;
     }
 }
 

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1392,6 +1392,8 @@ pub mod ffi {
             yMax: &mut f64,
             zMax: &mut f64,
         );
+        pub fn Bnd_Box_CornerMin(b: &Bnd_Box) -> UniquePtr<gp_Pnt>;
+        pub fn Bnd_Box_CornerMax(b: &Bnd_Box) -> UniquePtr<gp_Pnt>;
         pub fn GetGap(self: &Bnd_Box) -> f64;
         pub fn Set(self: Pin<&mut Bnd_Box>, p: &gp_Pnt);
         pub fn SetGap(self: Pin<&mut Bnd_Box>, gap: f64);

--- a/crates/opencascade/src/bounding_box.rs
+++ b/crates/opencascade/src/bounding_box.rs
@@ -55,7 +55,7 @@ mod test {
     }
 
     #[test]
-    fn get_min_when_void() {
+    fn get_min_max_of_new_box() {
         let mut bb = BoundingBox::new();
         let min = bb.min();
         let max = bb.max();

--- a/crates/opencascade/src/bounding_box.rs
+++ b/crates/opencascade/src/bounding_box.rs
@@ -2,6 +2,8 @@ use cxx::UniquePtr;
 use glam::DVec3;
 use opencascade_sys::ffi;
 
+use crate::primitives::Shape;
+
 pub struct BoundingBox {
     pub(crate) inner: UniquePtr<ffi::Bnd_Box>,
     min: DVec3,
@@ -45,6 +47,13 @@ impl BoundingBox {
     }
 }
 
+/// Compute the axis-aligned bounding box of `shape` using the `BRepBndLib`
+/// package.
+pub fn aabb(shape: &Shape) -> BoundingBox {
+    let mut bb = BoundingBox::new();
+    bb
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -63,5 +72,15 @@ mod test {
         assert!(min.x == 0.0 && max.x == 0.0);
         assert!(min.y == 0.0 && max.y == 0.0);
         assert!(min.z == 0.0 && max.z == 0.0);
+    }
+
+    #[test]
+    fn get_bounding_box_of_sphere() {
+        let s = Shape::sphere(1.).build();
+
+        let mut bb = aabb(&s);
+
+        assert_eq!(bb.min(), glam::dvec3(-1., -1., -1.));
+        assert_eq!(bb.max(), glam::dvec3(1., 1., 1.));
     }
 }

--- a/crates/opencascade/src/bounding_box.rs
+++ b/crates/opencascade/src/bounding_box.rs
@@ -36,6 +36,10 @@ impl BoundingBox {
         );
     }
 
+    pub fn get_gap(&self) -> f64 {
+        self.inner.GetGap()
+    }
+
     pub fn min(&mut self) -> DVec3 {
         self.get();
         self.min
@@ -85,7 +89,7 @@ mod test {
 
         let mut bb = aabb(&s);
 
-        assert_eq!(bb.min(), glam::dvec3(-1., -1., -1.));
-        assert_eq!(bb.max(), glam::dvec3(1., 1., 1.));
+        assert_eq!(bb.min(), glam::dvec3(-1., -1., -1.) + glam::DVec3::NEG_ONE * bb.get_gap());
+        assert_eq!(bb.max(), glam::dvec3(1., 1., 1.) + glam::DVec3::ONE * bb.get_gap());
     }
 }

--- a/crates/opencascade/src/bounding_box.rs
+++ b/crates/opencascade/src/bounding_box.rs
@@ -51,6 +51,11 @@ impl BoundingBox {
 /// package.
 pub fn aabb(shape: &Shape) -> BoundingBox {
     let mut bb = BoundingBox::new();
+    ffi::BRepBndLib_Add(
+        shape.inner.as_ref().expect("Input shape ref was null"),
+        bb.inner.pin_mut(),
+        true,
+    );
     bb
 }
 

--- a/crates/opencascade/src/bounding_box.rs
+++ b/crates/opencascade/src/bounding_box.rs
@@ -1,16 +1,46 @@
 use cxx::UniquePtr;
+use glam::DVec3;
 use opencascade_sys::ffi;
 
 pub struct BoundingBox {
     pub(crate) inner: UniquePtr<ffi::Bnd_Box>,
+    pub(crate) min: DVec3,
+    pub(crate) max: DVec3,
 }
 impl BoundingBox {
     pub fn new() -> BoundingBox {
-        Self { inner: ffi::Bnd_Box_ctor() }
+        let mut bnd_box = ffi::Bnd_Box_ctor();
+        let p = ffi::new_point(0., 0., 0.);
+        bnd_box.pin_mut().Set(&p);
+        Self { inner: bnd_box, min: DVec3::ZERO, max: DVec3::ZERO }
     }
 
-    pub fn is_void(self: &BoundingBox) -> bool {
+    pub fn is_void(&self) -> bool {
         self.inner.IsVoid()
+    }
+
+    pub fn min(&mut self) -> DVec3 {
+        self.inner.Get(
+            &mut self.min.x,
+            &mut self.min.y,
+            &mut self.min.z,
+            &mut self.max.x,
+            &mut self.max.y,
+            &mut self.max.z,
+        );
+        self.min
+    }
+
+    pub fn max(&mut self) -> DVec3 {
+        self.inner.Get(
+            &mut self.min.x,
+            &mut self.min.y,
+            &mut self.min.z,
+            &mut self.max.x,
+            &mut self.max.y,
+            &mut self.max.z,
+        );
+        self.max
     }
 }
 
@@ -21,10 +51,16 @@ mod test {
     #[test]
     fn create_bounding_box() {
         let bb = BoundingBox::new();
-        assert!(bb.is_void());
-        // let [mut x_min, mut y_min, mut z_min, mut x_max, mut y_max, mut z_max] = [0.; 6];
-        // bb.inner.Get(&mut x_min, &mut y_min, &mut z_min, &mut x_max, &mut y_max, &mut z_max);
-        // assert!(x_min > 0.);
-        // assert!(x_max < 0.);
+        assert!(!bb.is_void());
+    }
+
+    #[test]
+    fn get_min_when_void() {
+        let mut bb = BoundingBox::new();
+        let min = bb.min();
+        let max = bb.max();
+        assert!(min.x == 0.0 && max.x == 0.0);
+        assert!(min.y == 0.0 && max.y == 0.0);
+        assert!(min.z == 0.0 && max.z == 0.0);
     }
 }

--- a/crates/opencascade/src/bounding_box.rs
+++ b/crates/opencascade/src/bounding_box.rs
@@ -6,34 +6,18 @@ use crate::primitives::Shape;
 
 pub struct BoundingBox {
     pub(crate) inner: UniquePtr<ffi::Bnd_Box>,
-    min: DVec3,
-    max: DVec3,
 }
 impl BoundingBox {
     /// Create a new, valid bounding box with zero dimensions and volume.
     pub fn new() -> BoundingBox {
-        let mut bnd_box = ffi::Bnd_Box_ctor();
+        let mut inner = ffi::Bnd_Box_ctor();
         let p = ffi::new_point(0., 0., 0.);
-        bnd_box.pin_mut().Set(&p);
-        Self { inner: bnd_box, min: DVec3::ZERO, max: DVec3::ZERO }
+        inner.pin_mut().Set(&p);
+        Self { inner }
     }
 
     pub fn is_void(&self) -> bool {
         self.inner.IsVoid()
-    }
-
-    /// The underlying OCC API uses mutable pointers to get values out of the
-    /// `Bnd_Box`. We wrap this method to write those values straight into
-    /// `DVec3`s to return in the Rust API.
-    fn get(&mut self) {
-        self.inner.Get(
-            &mut self.min.x,
-            &mut self.min.y,
-            &mut self.min.z,
-            &mut self.max.x,
-            &mut self.max.y,
-            &mut self.max.z,
-        );
     }
 
     pub fn get_gap(&self) -> f64 {
@@ -41,13 +25,13 @@ impl BoundingBox {
     }
 
     pub fn min(&mut self) -> DVec3 {
-        self.get();
-        self.min
+        let p = ffi::Bnd_Box_CornerMin(self.inner.pin_mut().as_ref());
+        glam::dvec3(p.X(), p.Y(), p.Z())
     }
 
     pub fn max(&mut self) -> DVec3 {
-        self.get();
-        self.max
+        let p = ffi::Bnd_Box_CornerMax(self.inner.pin_mut().as_ref());
+        glam::dvec3(p.X(), p.Y(), p.Z())
     }
 }
 

--- a/crates/opencascade/src/bounding_box.rs
+++ b/crates/opencascade/src/bounding_box.rs
@@ -4,10 +4,11 @@ use opencascade_sys::ffi;
 
 pub struct BoundingBox {
     pub(crate) inner: UniquePtr<ffi::Bnd_Box>,
-    pub(crate) min: DVec3,
-    pub(crate) max: DVec3,
+    min: DVec3,
+    max: DVec3,
 }
 impl BoundingBox {
+    /// Create a new, valid bounding box with zero dimensions and volume.
     pub fn new() -> BoundingBox {
         let mut bnd_box = ffi::Bnd_Box_ctor();
         let p = ffi::new_point(0., 0., 0.);
@@ -19,7 +20,10 @@ impl BoundingBox {
         self.inner.IsVoid()
     }
 
-    pub fn min(&mut self) -> DVec3 {
+    /// The underlying OCC API uses mutable pointers to get values out of the
+    /// `Bnd_Box`. We wrap this method to write those values straight into
+    /// `DVec3`s to return in the Rust API.
+    fn get(&mut self) {
         self.inner.Get(
             &mut self.min.x,
             &mut self.min.y,
@@ -28,18 +32,15 @@ impl BoundingBox {
             &mut self.max.y,
             &mut self.max.z,
         );
+    }
+
+    pub fn min(&mut self) -> DVec3 {
+        self.get();
         self.min
     }
 
     pub fn max(&mut self) -> DVec3 {
-        self.inner.Get(
-            &mut self.min.x,
-            &mut self.min.y,
-            &mut self.min.z,
-            &mut self.max.x,
-            &mut self.max.y,
-            &mut self.max.z,
-        );
+        self.get();
         self.max
     }
 }

--- a/crates/opencascade/src/bounding_box.rs
+++ b/crates/opencascade/src/bounding_box.rs
@@ -24,13 +24,13 @@ impl BoundingBox {
         self.inner.GetGap()
     }
 
-    pub fn min(&mut self) -> DVec3 {
-        let p = ffi::Bnd_Box_CornerMin(self.inner.pin_mut().as_ref());
+    pub fn min(&self) -> DVec3 {
+        let p = ffi::Bnd_Box_CornerMin(self.inner.as_ref().unwrap());
         glam::dvec3(p.X(), p.Y(), p.Z())
     }
 
-    pub fn max(&mut self) -> DVec3 {
-        let p = ffi::Bnd_Box_CornerMax(self.inner.pin_mut().as_ref());
+    pub fn max(&self) -> DVec3 {
+        let p = ffi::Bnd_Box_CornerMax(self.inner.as_ref().unwrap());
         glam::dvec3(p.X(), p.Y(), p.Z())
     }
 }
@@ -59,7 +59,7 @@ mod test {
 
     #[test]
     fn get_min_max_of_new_box() {
-        let mut bb = BoundingBox::new();
+        let bb = BoundingBox::new();
         let min = bb.min();
         let max = bb.max();
         assert!(min.x == 0.0 && max.x == 0.0);
@@ -71,9 +71,19 @@ mod test {
     fn get_bounding_box_of_sphere() {
         let s = Shape::sphere(1.).build();
 
-        let mut bb = aabb(&s);
+        let bb = aabb(&s);
 
         assert_eq!(bb.min(), glam::dvec3(-1., -1., -1.) + glam::DVec3::NEG_ONE * bb.get_gap());
         assert_eq!(bb.max(), glam::dvec3(1., 1., 1.) + glam::DVec3::ONE * bb.get_gap());
+    }
+
+    #[test]
+    fn get_bounding_box_of_sphere_transformed() {
+        let s = Shape::sphere(1.).at(glam::dvec3(1., 2., 3.)).build();
+
+        let bb = aabb(&s);
+        let gap = glam::DVec3::ONE * bb.get_gap();
+        assert_eq!(bb.min(), glam::dvec3(0., 1., 2.) - gap);
+        assert_eq!(bb.max(), glam::dvec3(2., 3., 4.) + gap);
     }
 }

--- a/crates/opencascade/src/bounding_box.rs
+++ b/crates/opencascade/src/bounding_box.rs
@@ -65,21 +65,21 @@ mod test {
 
     #[test]
     fn get_bounding_box_of_sphere() {
-        let s = Shape::sphere(1.).build();
+        let s = Shape::sphere(1.0).build();
 
         let bb = aabb(&s);
 
-        assert_eq!(bb.min(), glam::dvec3(-1., -1., -1.) - bb.gap_vec());
-        assert_eq!(bb.max(), glam::dvec3(1., 1., 1.) + bb.gap_vec());
+        assert_eq!(bb.min(), glam::dvec3(-1.0, -1.0, -1.0) - bb.gap_vec());
+        assert_eq!(bb.max(), glam::dvec3(1.0, 1.0, 1.0) + bb.gap_vec());
     }
 
     #[test]
     fn get_bounding_box_of_sphere_transformed() {
-        let s = Shape::sphere(1.).at(glam::dvec3(1., 2., 3.)).build();
+        let s = Shape::sphere(1.0).at(glam::dvec3(1.0, 2.0, 3.0)).build();
 
         let bb = aabb(&s);
         let gap = bb.gap_vec();
-        assert_eq!(bb.min(), glam::dvec3(0., 1., 2.) - gap);
-        assert_eq!(bb.max(), glam::dvec3(2., 3., 4.) + gap);
+        assert_eq!(bb.min(), glam::dvec3(0.0, 1.0, 2.0) - gap);
+        assert_eq!(bb.max(), glam::dvec3(2.0, 3.0, 4.0) + gap);
     }
 }

--- a/crates/opencascade/src/bounding_box.rs
+++ b/crates/opencascade/src/bounding_box.rs
@@ -1,0 +1,30 @@
+use cxx::UniquePtr;
+use opencascade_sys::ffi;
+
+pub struct BoundingBox {
+    pub(crate) inner: UniquePtr<ffi::Bnd_Box>,
+}
+impl BoundingBox {
+    pub fn new() -> BoundingBox {
+        Self { inner: ffi::Bnd_Box_ctor() }
+    }
+
+    pub fn is_void(self: &BoundingBox) -> bool {
+        self.inner.IsVoid()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn create_bounding_box() {
+        let bb = BoundingBox::new();
+        assert!(bb.is_void());
+        // let [mut x_min, mut y_min, mut z_min, mut x_max, mut y_max, mut z_max] = [0.; 6];
+        // bb.inner.Get(&mut x_min, &mut y_min, &mut z_min, &mut x_max, &mut y_max, &mut z_max);
+        // assert!(x_min > 0.);
+        // assert!(x_max < 0.);
+    }
+}

--- a/crates/opencascade/src/lib.rs
+++ b/crates/opencascade/src/lib.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 pub mod angle;
+pub mod bounding_box;
 pub mod kicad;
 pub mod mesh;
 pub mod primitives;

--- a/examples/src/bounding_box.rs
+++ b/examples/src/bounding_box.rs
@@ -1,6 +1,8 @@
-use opencascade::bounding_box;
-use opencascade::primitives::{Compound, IntoShape, Shape};
-use opencascade::workplane::Workplane;
+use opencascade::{
+    bounding_box,
+    primitives::{Compound, IntoShape, Shape},
+    workplane::Workplane,
+};
 
 pub fn shape() -> Shape {
     let mut shapes = vec![];

--- a/examples/src/bounding_box.rs
+++ b/examples/src/bounding_box.rs
@@ -1,0 +1,33 @@
+use opencascade::bounding_box;
+use opencascade::primitives::{Compound, IntoShape, Shape};
+use opencascade::workplane::Workplane;
+
+pub fn shape() -> Shape {
+    let mut shapes = vec![];
+
+    // Create some non-orthogonal shapes.
+    for i in 0..=1 {
+        // NOTE: Try changing the range values and the position vector
+        let v = (2i32.pow(i)) as f64;
+        let s = Shape::sphere(1.).at(glam::dvec3(v, v, v * 2.)).build();
+        shapes.push(s);
+    }
+
+    // Add a circle to show that edges work, too.
+    shapes.push(Workplane::xy().circle(0., 0., 2.).into_shape());
+
+    // Combine them to create a bounding box.
+    let c = Compound::from_shapes(shapes);
+
+    // Create the bounding box.
+    let bb = bounding_box::aabb(&Shape::from(&c));
+
+    // Create a box geometry for rendering.
+    let bb_shape = Shape::box_from_corners(bb.min(), bb.max());
+
+    let all_shapes =
+        [vec![c.into_shape()], bb_shape.edges().map(|e| e.into_shape()).collect::<Vec<_>>()];
+
+    // Combine the bounded and bounding geometry.
+    Compound::from_shapes(all_shapes.iter().flatten()).into_shape()
+}

--- a/examples/src/bounding_box.rs
+++ b/examples/src/bounding_box.rs
@@ -9,12 +9,12 @@ pub fn shape() -> Shape {
     for i in 0..=1 {
         // NOTE: Try changing the range values and the position vector
         let v = (2i32.pow(i)) as f64;
-        let s = Shape::sphere(1.).at(glam::dvec3(v, v, v * 2.)).build();
+        let s = Shape::sphere(1.0).at(glam::dvec3(v, v, v * 2.0)).build();
         shapes.push(s);
     }
 
     // Add a circle to show that edges work, too.
-    shapes.push(Workplane::xy().circle(0., 0., 2.).into_shape());
+    shapes.push(Workplane::xy().circle(0.0, 0.0, 2.0).into_shape());
 
     // Combine them to create a bounding box.
     let c = Compound::from_shapes(shapes);

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -2,6 +2,7 @@ use clap::ValueEnum;
 use opencascade::primitives::Shape;
 
 pub mod airfoil;
+pub mod bounding_box;
 pub mod box_shape;
 pub mod cable_bracket;
 pub mod chamfer;
@@ -26,6 +27,7 @@ pub mod zbox_case;
 #[derive(Debug, Copy, Clone, PartialEq, ValueEnum)]
 pub enum Example {
     Airfoil,
+    BoundingBox,
     CableBracket,
     BoxShape,
     Chamfer,
@@ -52,6 +54,7 @@ impl Example {
     pub fn shape(self) -> Shape {
         match self {
             Example::Airfoil => airfoil::shape(),
+            Example::BoundingBox => bounding_box::shape(),
             Example::CableBracket => cable_bracket::shape(),
             Example::BoxShape => box_shape::shape(),
             Example::Chamfer => chamfer::shape(),


### PR DESCRIPTION
## Summary
- Add `bounding_box` module wrapping `Bnd_Box` and `BRepBndLib`
- Add tests
- Add `bounding_box` example

## Description
I need to compute bounding boxes of OCC geometry for a project that uses `opencascade`. Thankfully, OCC has the `BRepBndLib` package that supports this already. This adds a wrapper for the `BRepBndLib::Add` method and the underlying `Bnd_Box` class on which it depends.

To support this and show how to use it, there are a few simple tests and an example that uses the viewer to show the bounded and bounding geometry.

One thing that I didn't understand, but that I assume is important to the underlying algorithms in OCC, is that the `Bnd_Box` has a small `Gap` value that is added to every dimension of the box. I decided to expose this as `gap_vec` to make it easier to work with in the rust side and tried to document it clearly.