### PR TITLE
Add `Shape::transform`

### DIFF
--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1027,6 +1027,21 @@ pub mod ffi {
         pub fn SetScale(self: Pin<&mut gp_Trsf>, point: &gp_Pnt, scale: f64);
         pub fn SetTranslation(self: Pin<&mut gp_Trsf>, point1: &gp_Pnt, point2: &gp_Pnt);
         pub fn Value(self: &gp_Trsf, the_row: i32, the_col: i32) -> f64;
+        pub fn SetValues(
+            self: Pin<&mut gp_Trsf>,
+            a11: f64,
+            a12: f64,
+            a13: f64,
+            a14: f64,
+            a21: f64,
+            a22: f64,
+            a23: f64,
+            a24: f64,
+            a31: f64,
+            a32: f64,
+            a33: f64,
+            a34: f64,
+        );
 
         #[cxx_name = "SetTranslationPart"]
         pub fn set_translation_vec(self: Pin<&mut gp_Trsf>, translation: &gp_Vec);
@@ -1403,6 +1418,8 @@ pub mod ffi {
         type BRepBndLib;
 
         pub fn BRepBndLib_Add(shape: &TopoDS_Shape, bb: Pin<&mut Bnd_Box>, use_triangulation: bool);
+
+        // BRep
     }
 }
 

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1027,6 +1027,7 @@ pub mod ffi {
         pub fn SetScale(self: Pin<&mut gp_Trsf>, point: &gp_Pnt, scale: f64);
         pub fn SetTranslation(self: Pin<&mut gp_Trsf>, point1: &gp_Pnt, point2: &gp_Pnt);
         pub fn Value(self: &gp_Trsf, the_row: i32, the_col: i32) -> f64;
+        #[allow(clippy::too_many_arguments)]
         pub fn SetValues(
             self: Pin<&mut gp_Trsf>,
             a11: f64,

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1418,8 +1418,6 @@ pub mod ffi {
         type BRepBndLib;
 
         pub fn BRepBndLib_Add(shape: &TopoDS_Shape, bb: Pin<&mut Bnd_Box>, use_triangulation: bool);
-
-        // BRep
     }
 }
 

--- a/crates/opencascade/src/lib.rs
+++ b/crates/opencascade/src/lib.rs
@@ -6,6 +6,7 @@ pub mod kicad;
 pub mod mesh;
 pub mod primitives;
 pub mod section;
+pub mod transform;
 pub mod workplane;
 
 mod law_function;

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -631,8 +631,12 @@ impl Shape {
         self.inner.pin_mut().set_global_translation(&location, false);
     }
 
+    /// Copy `self` using the upper 3x4 matrix of `transform`.
     pub fn transform(&self, transform: &DMat4) -> Self {
-        Self::from_shape(&self.inner)
+        let t = crate::transform::gp_trsf(transform);
+        // NOTE: Setting the copy argument does not seem to have an effect.
+        let mut res = ffi::BRepBuilderAPI_Transform_ctor(&self.inner, &t, true);
+        Self::from_shape(res.pin_mut().Shape())
     }
 
     pub fn mesh(&self) -> Result<Mesh, Error> {

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -770,13 +770,12 @@ mod test {
     #[test]
     fn transform_shape() {
         let s = Workplane::xy().sketch().line_to(1.0, 2.0).wire().into_shape();
+        let t = s.transform(&glam::DMat4::from_translation(glam::dvec3(2.0, 3.0, 4.0)));
 
         for p in s.edges() {
             assert_eq!(p.start_point(), glam::dvec3(0.0, 0.0, 0.0));
             assert_eq!(p.end_point(), glam::dvec3(1.0, 2.0, 0.0));
         }
-
-        let t = s.transform(&glam::DMat4::from_translation(glam::dvec3(2.0, 3.0, 4.0)));
 
         for p in t.edges() {
             assert_eq!(p.start_point(), glam::dvec3(2.0, 3.0, 4.0));

--- a/crates/opencascade/src/transform.rs
+++ b/crates/opencascade/src/transform.rs
@@ -2,6 +2,13 @@ use cxx::UniquePtr;
 use glam::DMat4;
 use opencascade_sys::ffi;
 
+/// Create a `gp_Trsf` from a `DMat4`.
+///
+/// Note that OCC only allows setting values for the upper 3x4 matrix. I.e. the
+/// XYZ components of each column.
+///
+/// Additionally, OCC ensures orthogonality of the matrix before the method
+/// returns.
 pub fn gp_trsf(mat: &DMat4) -> UniquePtr<ffi::gp_Trsf> {
     let mut t = ffi::new_transform();
     t.pin_mut().SetValues(
@@ -26,6 +33,7 @@ mod test {
     use super::*;
     #[test]
     fn set_gp_trsf_values() {
+        // Matrix with permuted axes
         let m = glam::dmat4(
             glam::dvec4(0.0, 0.0, 1.0, 0.0),
             glam::dvec4(1.0, 0.0, 0.0, 0.0),

--- a/crates/opencascade/src/transform.rs
+++ b/crates/opencascade/src/transform.rs
@@ -1,0 +1,42 @@
+use cxx::UniquePtr;
+use glam::DMat4;
+use opencascade_sys::ffi;
+
+pub fn gp_trsf(mat: &DMat4) -> UniquePtr<ffi::gp_Trsf> {
+    let mut t = ffi::new_transform();
+    t.pin_mut().SetValues(
+        mat.x_axis.x,
+        mat.y_axis.x,
+        mat.z_axis.x,
+        mat.w_axis.x,
+        mat.x_axis.y,
+        mat.y_axis.y,
+        mat.z_axis.y,
+        mat.w_axis.y,
+        mat.x_axis.z,
+        mat.y_axis.z,
+        mat.z_axis.z,
+        mat.w_axis.z,
+    );
+    t
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn set_gp_trsf_values() {
+        let m = glam::dmat4(
+            glam::dvec4(0.0, 0.0, 1.0, 0.0),
+            glam::dvec4(1.0, 0.0, 0.0, 0.0),
+            glam::dvec4(0.0, 1.0, 0.0, 0.0),
+            glam::dvec4(0.0, 0.0, 0.0, 1.0),
+        );
+
+        let m = glam::DMat4::IDENTITY;
+
+        let t = gp_trsf(&m);
+
+        assert_eq!(t.Value(0, 0), 0.0);
+    }
+}

--- a/crates/opencascade/src/transform.rs
+++ b/crates/opencascade/src/transform.rs
@@ -33,10 +33,16 @@ mod test {
             glam::dvec4(0.0, 0.0, 0.0, 1.0),
         );
 
-        let m = glam::DMat4::IDENTITY;
-
         let t = gp_trsf(&m);
 
-        assert_eq!(t.Value(0, 0), 0.0);
+        // 3D diagonal is 0
+        assert_eq!(t.Value(1, 1), 0.0);
+        assert_eq!(t.Value(2, 2), 0.0);
+        assert_eq!(t.Value(3, 3), 0.0);
+
+        // Permuted axes are preserved
+        assert_eq!(t.Value(1, 2), 1.0);
+        assert_eq!(t.Value(3, 1), 1.0);
+        assert_eq!(t.Value(2, 3), 1.0);
     }
 }


### PR DESCRIPTION
## Summary
- Expose `gp_Trsf::SetValues`
- Add `transform` module, tests
- Add `gp_trsf(&DMat4) -> gp_Trsf`
- Add `Shape::transform`

## Description
I needed a way to define a `Shape` once and then duplicate that geometry throughout a model space using transform matrices, similar to "blocks" from the CAD world or "instanced rendering" from the GPU programming world.

This PR exposes OCC's implementation of this capability through the `BRepBuilderAPI_Transform` class. This requires using a `gp_Trsf` instance as the transform matrix. There didn't seem to be a convenient way to construct these from a `glam` type, so I added the `transform` module and a simple test to ensure the construction is correct.

One caveat here (that is also noted in the comments) is that the `gp_Trsf` constructor:
- Only allows setting the upper 3x4 matrix 
  - I.e. cannot set the `w` component of any column
- Orthogonalizes the matrix

So, the values of the output can be different than the input based on the orthogonality of the input.