### PR TITLE
Fix Windows build: CMake profile matching and missing system libraries

### DIFF
--- a/crates/occt-sys/src/lib.rs
+++ b/crates/occt-sys/src/lib.rs
@@ -18,6 +18,10 @@ pub fn occt_path() -> PathBuf {
 
 /// Build the OCCT library.
 pub fn build_occt() {
+    // Get the Cargo profile and map it to CMake build type
+    let profile = var("PROFILE").unwrap_or_else(|_| "debug".to_string());
+    let cmake_profile = if profile == "release" { "Release" } else { "Debug" };
+    
     cmake::Config::new(Path::new(env!("OCCT_SRC_DIR")))
         .define("BUILD_PATCH", Path::new(env!("OCCT_PATCH_DIR")))
         .define("BUILD_LIBRARY_TYPE", "Static")
@@ -40,7 +44,7 @@ pub fn build_occt() {
         .define("USE_XLIB", "FALSE")
         .define("INSTALL_DIR_LIB", LIB_DIR)
         .define("INSTALL_DIR_INCLUDE", INCLUDE_DIR)
-        .profile("Release")
+        .profile(cmake_profile)
         .out_dir(occt_path())
         .build();
 }

--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -47,6 +47,10 @@ fn main() {
 
     if is_windows {
         println!("cargo:rustc-link-lib=dylib=user32");
+        println!("cargo:rustc-link-lib=dylib=advapi32");
+        println!("cargo:rustc-link-lib=dylib=gdi32");
+        println!("cargo:rustc-link-lib=dylib=shell32");
+        println!("cargo:rustc-link-lib=dylib=comdlg32");
     }
 
     let mut build = cxx_build::bridge("src/lib.rs");


### PR DESCRIPTION
## Problem
Building on Windows with MSVC fails with two issues:
1. **PDB file errors**: CMake is hardcoded to Release profile, causing "cannot find TKernel.pdb" errors when building with `cargo build` (debug mode)
2. **Linker errors**: Missing Windows system libraries causing 23 unresolved external symbols (e.g., `SetFileSecurityW`, `OpenProcessToken`, `RegOpenKeyW`)

## Solution
1. **`crates/occt-sys/src/lib.rs`**: Read `PROFILE` environment variable from Cargo and pass the correct profile to CMake (Debug vs Release)
2. **`crates/opencascade-sys/build.rs`**: Add missing Windows system libraries:
   - `advapi32.lib` - Security and registry APIs
   - `gdi32.lib` - Graphics Device Interface
   - `shell32.lib` - Windows Shell API
   - `comdlg32.lib` - Common Dialog Box

## Testing
- [x] Successfully builds on Windows 11 with `cargo build --release`
- [x] Successfully builds on Windows 11 with `cargo build` (debug)
- [x] Both MSVC Release and Debug profiles now work correctly

## Notes
This appears to be Windows-specific as Linux builds work fine (debug symbols are embedded in binaries, and these Windows libraries aren't needed).

Fixes the build issues reported by Windows users.