### PR TITLE
Add BRep I/O support (Text and Binary)

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -39,6 +39,7 @@
 #include <BRepPrimAPI_MakeTorus.hxx>
 #include <BRepTools.hxx>
 #include <BRep_Builder.hxx>
+#include <BinTools.hxx>
 #include <GCE2d_MakeSegment.hxx>
 #include <GCPnts_TangentialDeflection.hxx>
 #include <GC_MakeArcOfCircle.hxx>
@@ -467,9 +468,11 @@ inline std::unique_ptr<TopoDS_Wire> outer_wire(const TopoDS_Face &face) {
   return std::unique_ptr<TopoDS_Wire>(new TopoDS_Wire(BRepTools::OuterWire(face)));
 }
 
-inline bool write_brep(const TopoDS_Shape &shape, rust::String path) { return BRepTools::Write(shape, path.c_str()); }
+inline bool write_brep_text(const TopoDS_Shape &shape, rust::String path) {
+  return BRepTools::Write(shape, path.c_str());
+}
 
-inline std::unique_ptr<TopoDS_Shape> read_brep(rust::String path) {
+inline std::unique_ptr<TopoDS_Shape> read_brep_text(rust::String path) {
   BRep_Builder builder;
   auto shape = std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape());
   if (BRepTools::Read(*shape, path.c_str(), builder)) {
@@ -479,7 +482,6 @@ inline std::unique_ptr<TopoDS_Shape> read_brep(rust::String path) {
 }
 
 // BinTools
-#include <BinTools.hxx>
 inline bool write_brep_bin(const TopoDS_Shape &shape, rust::String path) {
   return BinTools::Write(shape, path.c_str());
 }

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -37,6 +37,7 @@
 #include <BRepPrimAPI_MakeRevol.hxx>
 #include <BRepPrimAPI_MakeSphere.hxx>
 #include <BRepPrimAPI_MakeTorus.hxx>
+#include <BRep_Builder.hxx>
 #include <BRepTools.hxx>
 #include <GCE2d_MakeSegment.hxx>
 #include <GCPnts_TangentialDeflection.hxx>
@@ -464,6 +465,19 @@ BRepFilletAPI_MakeFillet2d_add_chamfer_angle(BRepFilletAPI_MakeFillet2d &make_fi
 // BRepTools
 inline std::unique_ptr<TopoDS_Wire> outer_wire(const TopoDS_Face &face) {
   return std::unique_ptr<TopoDS_Wire>(new TopoDS_Wire(BRepTools::OuterWire(face)));
+}
+
+inline bool write_brep(const TopoDS_Shape &shape, const rust::String &path) {
+  return BRepTools::Write(shape, path.c_str());
+}
+
+inline std::unique_ptr<TopoDS_Shape> read_brep(const rust::String &path) {
+  BRep_Builder builder;
+  auto shape = std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape());
+  if (BRepTools::Read(*shape, path.c_str(), builder)) {
+    return shape;
+  }
+  return std::unique_ptr<TopoDS_Shape>(nullptr);
 }
 
 // Collections

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -37,8 +37,8 @@
 #include <BRepPrimAPI_MakeRevol.hxx>
 #include <BRepPrimAPI_MakeSphere.hxx>
 #include <BRepPrimAPI_MakeTorus.hxx>
-#include <BRep_Builder.hxx>
 #include <BRepTools.hxx>
+#include <BRep_Builder.hxx>
 #include <GCE2d_MakeSegment.hxx>
 #include <GCPnts_TangentialDeflection.hxx>
 #include <GC_MakeArcOfCircle.hxx>
@@ -467,9 +467,7 @@ inline std::unique_ptr<TopoDS_Wire> outer_wire(const TopoDS_Face &face) {
   return std::unique_ptr<TopoDS_Wire>(new TopoDS_Wire(BRepTools::OuterWire(face)));
 }
 
-inline bool write_brep(const TopoDS_Shape &shape, rust::String path) {
-  return BRepTools::Write(shape, path.c_str());
-}
+inline bool write_brep(const TopoDS_Shape &shape, rust::String path) { return BRepTools::Write(shape, path.c_str()); }
 
 inline std::unique_ptr<TopoDS_Shape> read_brep(rust::String path) {
   BRep_Builder builder;

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -467,11 +467,11 @@ inline std::unique_ptr<TopoDS_Wire> outer_wire(const TopoDS_Face &face) {
   return std::unique_ptr<TopoDS_Wire>(new TopoDS_Wire(BRepTools::OuterWire(face)));
 }
 
-inline bool write_brep(const TopoDS_Shape &shape, const rust::String &path) {
+inline bool write_brep(const TopoDS_Shape &shape, rust::String path) {
   return BRepTools::Write(shape, path.c_str());
 }
 
-inline std::unique_ptr<TopoDS_Shape> read_brep(const rust::String &path) {
+inline std::unique_ptr<TopoDS_Shape> read_brep(rust::String path) {
   BRep_Builder builder;
   auto shape = std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape());
   if (BRepTools::Read(*shape, path.c_str(), builder)) {

--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -480,6 +480,20 @@ inline std::unique_ptr<TopoDS_Shape> read_brep(rust::String path) {
   return std::unique_ptr<TopoDS_Shape>(nullptr);
 }
 
+// BinTools
+#include <BinTools.hxx>
+inline bool write_brep_bin(const TopoDS_Shape &shape, rust::String path) {
+  return BinTools::Write(shape, path.c_str());
+}
+
+inline std::unique_ptr<TopoDS_Shape> read_brep_bin(rust::String path) {
+  auto shape = std::unique_ptr<TopoDS_Shape>(new TopoDS_Shape());
+  if (BinTools::Read(*shape, path.c_str())) {
+    return shape;
+  }
+  return std::unique_ptr<TopoDS_Shape>(nullptr);
+}
+
 // Collections
 inline void map_shapes(const TopoDS_Shape &S, const TopAbs_ShapeEnum T, TopTools_IndexedMapOfShape &M) {
   TopExp::MapShapes(S, T, M);

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1356,8 +1356,12 @@ pub mod ffi {
 
         // BRepTools
         pub fn outer_wire(face: &TopoDS_Face) -> UniquePtr<TopoDS_Wire>;
-        pub fn write_brep(shape: &TopoDS_Shape, path: String) -> bool;
-        pub fn read_brep(path: String) -> UniquePtr<TopoDS_Shape>;
+        pub fn write_brep_text(shape: &TopoDS_Shape, path: String) -> bool;
+        pub fn read_brep_text(path: String) -> UniquePtr<TopoDS_Shape>;
+
+        // BinTools
+        pub fn write_brep_bin(shape: &TopoDS_Shape, path: String) -> bool;
+        pub fn read_brep_bin(path: String) -> UniquePtr<TopoDS_Shape>;
 
         // Cleaning
         type ShapeUpgrade_UnifySameDomain;
@@ -1408,9 +1412,6 @@ pub mod ffi {
 
         pub fn BRepBndLib_Add(shape: &TopoDS_Shape, bb: Pin<&mut Bnd_Box>, use_triangulation: bool);
 
-        // BinTools
-        pub fn write_brep_bin(shape: &TopoDS_Shape, path: String) -> bool;
-        pub fn read_brep_bin(path: String) -> UniquePtr<TopoDS_Shape>;
     }
 }
 

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1356,6 +1356,8 @@ pub mod ffi {
 
         // BRepTools
         pub fn outer_wire(face: &TopoDS_Face) -> UniquePtr<TopoDS_Wire>;
+        pub fn write_brep(shape: &TopoDS_Shape, path: String) -> bool;
+        pub fn read_brep(path: String) -> UniquePtr<TopoDS_Shape>;
 
         // Cleaning
         type ShapeUpgrade_UnifySameDomain;

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -1407,6 +1407,10 @@ pub mod ffi {
         type BRepBndLib;
 
         pub fn BRepBndLib_Add(shape: &TopoDS_Shape, bb: Pin<&mut Bnd_Box>, use_triangulation: bool);
+
+        // BinTools
+        pub fn write_brep_bin(shape: &TopoDS_Shape, path: String) -> bool;
+        pub fn read_brep_bin(path: String) -> UniquePtr<TopoDS_Shape>;
     }
 }
 

--- a/crates/opencascade/src/lib.rs
+++ b/crates/opencascade/src/lib.rs
@@ -25,6 +25,10 @@ pub enum Error {
     StepWriteFailed,
     #[error("failed to write IGES file")]
     IgesWriteFailed,
+    #[error("failed to read BREP file")]
+    BrepReadFailed,
+    #[error("failed to write BREP file")]
+    BrepWriteFailed,
     #[error("failed to triangulate Shape")]
     TriangulationFailed,
     #[error("encountered a face with no triangulation")]

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -590,6 +590,26 @@ impl Shape {
         }
     }
 
+    pub fn write_brep_bin(&self, path: impl AsRef<Path>) -> Result<(), Error> {
+        let success = ffi::write_brep_bin(&self.inner, path.as_ref().to_string_lossy().to_string());
+
+        if success {
+            Ok(())
+        } else {
+            Err(Error::BrepWriteFailed)
+        }
+    }
+
+    pub fn read_brep_bin(path: impl AsRef<Path>) -> Result<Self, Error> {
+        let inner = ffi::read_brep_bin(path.as_ref().to_string_lossy().to_string());
+
+        if inner.is_null() {
+            Err(Error::BrepReadFailed)
+        } else {
+            Ok(Self { inner })
+        }
+    }
+
     #[must_use]
     pub fn union(&self, other: &Shape) -> BooleanShape {
         let mut fuse_operation = ffi::BRepAlgoAPI_Fuse_ctor(&self.inner, &other.inner);

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -570,6 +570,26 @@ impl Shape {
         }
     }
 
+    pub fn write_brep(&self, path: impl AsRef<Path>) -> Result<(), Error> {
+        let success = ffi::write_brep(&self.inner, path.as_ref().to_string_lossy().to_string());
+
+        if success {
+            Ok(())
+        } else {
+            Err(Error::BrepWriteFailed)
+        }
+    }
+
+    pub fn read_brep(path: impl AsRef<Path>) -> Result<Self, Error> {
+        let inner = ffi::read_brep(path.as_ref().to_string_lossy().to_string());
+
+        if inner.is_null() {
+            Err(Error::BrepReadFailed)
+        } else {
+            Ok(Self { inner })
+        }
+    }
+
     #[must_use]
     pub fn union(&self, other: &Shape) -> BooleanShape {
         let mut fuse_operation = ffi::BRepAlgoAPI_Fuse_ctor(&self.inner, &other.inner);

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -570,8 +570,9 @@ impl Shape {
         }
     }
 
-    pub fn write_brep(&self, path: impl AsRef<Path>) -> Result<(), Error> {
-        let success = ffi::write_brep(&self.inner, path.as_ref().to_string_lossy().to_string());
+    pub fn write_brep_text(&self, path: impl AsRef<Path>) -> Result<(), Error> {
+        let success =
+            ffi::write_brep_text(&self.inner, path.as_ref().to_string_lossy().to_string());
 
         if success {
             Ok(())
@@ -580,8 +581,8 @@ impl Shape {
         }
     }
 
-    pub fn read_brep(path: impl AsRef<Path>) -> Result<Self, Error> {
-        let inner = ffi::read_brep(path.as_ref().to_string_lossy().to_string());
+    pub fn read_brep_text(path: impl AsRef<Path>) -> Result<Self, Error> {
+        let inner = ffi::read_brep_text(path.as_ref().to_string_lossy().to_string());
 
         if inner.is_null() {
             Err(Error::BrepReadFailed)


### PR DESCRIPTION
## Summary
- Add BRepTools support for text-based BRep I/O (read_brep / write_brep)
- Add BinTools support for binary BRep I/O (read_brep_bin / write_brep_bin)
- Expose these methods on the Shape struct

## Description

I needed a way to cache parsed STEP files because Shape::read_step is extremely slow for complex models. For example, a 6MB STEP file takes ~2 minutes to load. OpenCascade supports native BRep serialization (both text and binary) which is orders of magnitude faster than re-parsing STEP.