### PR TITLE
Add BSpline curve data extraction from Edge

### DIFF
--- a/crates/opencascade-sys/include/wrapper.hxx
+++ b/crates/opencascade-sys/include/wrapper.hxx
@@ -51,6 +51,9 @@
 #include <GeomAbs_JoinType.hxx>
 #include <Geom_BezierCurve.hxx>
 #include <Geom_BezierSurface.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <GeomConvert_CompCurveToBSplineCurve.hxx>
+#include <TColStd_Array1OfReal.hxx>
 #include <Geom_CylindricalSurface.hxx>
 #include <Geom_Plane.hxx>
 #include <Geom_Surface.hxx>
@@ -539,4 +542,106 @@ inline std::unique_ptr<gp_Pnt> Bnd_Box_CornerMax(const Bnd_Box &box) {
 // BRepBndLib
 inline void BRepBndLib_Add(const TopoDS_Shape &shape, Bnd_Box &box, const Standard_Boolean useTriangulation) {
   BRepBndLib::Add(shape, box, useTriangulation);
+}
+
+// ============================================================================
+// BSpline Curve Data Extraction
+// ============================================================================
+
+// Get the BSpline curve handle from an edge (if it is a BSpline)
+inline std::unique_ptr<HandleGeomBSplineCurve>
+Edge_BSplineCurve(const TopoDS_Edge &edge) {
+  Standard_Real first, last;
+  opencascade::handle<Geom_Curve> curve = BRep_Tool::Curve(edge, first, last);
+  if (curve.IsNull()) return nullptr;
+
+  // Try direct cast first
+  opencascade::handle<Geom_BSplineCurve> bspline =
+      opencascade::handle<Geom_BSplineCurve>::DownCast(curve);
+
+  if (bspline.IsNull()) {
+    // Convert via Geom_TrimmedCurve (which IS a Geom_BoundedCurve)
+    opencascade::handle<Geom_TrimmedCurve> trimmed =
+        new Geom_TrimmedCurve(curve, first, last);
+    GeomConvert_CompCurveToBSplineCurve converter;
+    if (converter.Add(trimmed, 1e-7)) {
+      bspline = converter.BSplineCurve();
+    }
+  }
+
+  if (bspline.IsNull()) return nullptr;
+  return std::unique_ptr<HandleGeomBSplineCurve>(new HandleGeomBSplineCurve(bspline));
+}
+
+// BSpline properties
+inline int32_t Geom_BSplineCurve_Degree(const HandleGeomBSplineCurve &handle) {
+  return handle->Degree();
+}
+
+inline int32_t Geom_BSplineCurve_NbPoles(const HandleGeomBSplineCurve &handle) {
+  return handle->NbPoles();
+}
+
+inline int32_t Geom_BSplineCurve_NbKnots(const HandleGeomBSplineCurve &handle) {
+  return handle->NbKnots();
+}
+
+inline bool Geom_BSplineCurve_IsRational(const HandleGeomBSplineCurve &handle) {
+  return handle->IsRational();
+}
+
+// Bulk extraction: copy all poles into flat array [x1,y1,z1,x2,y2,z2,...]
+// Caller must ensure out.size() >= NbPoles * 3
+inline void Geom_BSplineCurve_Poles(
+    const HandleGeomBSplineCurve &handle, rust::Slice<double> out) {
+  int32_t n = handle->NbPoles();
+  for (int32_t i = 1; i <= n && (i-1)*3+2 < static_cast<int32_t>(out.size()); ++i) {
+    gp_Pnt p = handle->Pole(i);
+    out[(i-1)*3]   = p.X();
+    out[(i-1)*3+1] = p.Y();
+    out[(i-1)*3+2] = p.Z();
+  }
+}
+
+// Bulk extraction: copy all knots (with multiplicities expanded)
+// Uses KnotSequence() which returns the flat knot vector
+// Caller must ensure out.size() >= NbPoles + Degree + 1
+inline void Geom_BSplineCurve_KnotSequence(
+    const HandleGeomBSplineCurve &handle, rust::Slice<double> out) {
+  const TColStd_Array1OfReal &seq = handle->KnotSequence();
+  int32_t len = seq.Length();
+  for (int32_t i = 0; i < len && i < static_cast<int32_t>(out.size()); ++i) {
+    out[i] = seq.Value(seq.Lower() + i);
+  }
+}
+
+// Bulk extraction: copy all weights
+// Caller must ensure out.size() >= NbPoles
+inline void Geom_BSplineCurve_Weights(
+    const HandleGeomBSplineCurve &handle, rust::Slice<double> out) {
+  int32_t n = handle->NbPoles();
+  for (int32_t i = 1; i <= n && (i-1) < static_cast<int32_t>(out.size()); ++i) {
+    out[i-1] = handle->Weight(i);
+  }
+}
+
+// Keep individual accessors for flexibility
+inline std::unique_ptr<gp_Pnt> Geom_BSplineCurve_Pole(
+    const HandleGeomBSplineCurve &handle, int32_t index) {
+  return std::unique_ptr<gp_Pnt>(new gp_Pnt(handle->Pole(index)));
+}
+
+inline double Geom_BSplineCurve_Knot(
+    const HandleGeomBSplineCurve &handle, int32_t index) {
+  return handle->Knot(index);
+}
+
+inline int32_t Geom_BSplineCurve_Multiplicity(
+    const HandleGeomBSplineCurve &handle, int32_t index) {
+  return handle->Multiplicity(index);
+}
+
+inline double Geom_BSplineCurve_Weight(
+    const HandleGeomBSplineCurve &handle, int32_t index) {
+  return handle->Weight(index);
 }

--- a/crates/opencascade-sys/src/lib.rs
+++ b/crates/opencascade-sys/src/lib.rs
@@ -119,6 +119,7 @@ pub mod ffi {
 
         pub fn IsNull(self: &HandleStandardType) -> bool;
         pub fn IsNull(self: &HandleGeomCurve) -> bool;
+        pub fn IsNull(self: &HandleGeomBSplineCurve) -> bool;
         pub fn IsNull(self: &HandleGeomTrimmedCurve) -> bool;
         pub fn IsNull(self: &HandleGeomSurface) -> bool;
         pub fn IsNull(self: &HandleGeomBezierSurface) -> bool;
@@ -1130,6 +1131,27 @@ pub mod ffi {
             last: &mut f64,
         ) -> UniquePtr<HandleGeomCurve>;
         pub fn BRep_Tool_Pnt(vertex: &TopoDS_Vertex) -> UniquePtr<gp_Pnt>;
+
+        // BSpline curve data extraction
+        pub fn Edge_BSplineCurve(edge: &TopoDS_Edge) -> UniquePtr<HandleGeomBSplineCurve>;
+        pub fn Geom_BSplineCurve_Degree(handle: &HandleGeomBSplineCurve) -> i32;
+        pub fn Geom_BSplineCurve_NbPoles(handle: &HandleGeomBSplineCurve) -> i32;
+        pub fn Geom_BSplineCurve_NbKnots(handle: &HandleGeomBSplineCurve) -> i32;
+        pub fn Geom_BSplineCurve_IsRational(handle: &HandleGeomBSplineCurve) -> bool;
+
+        // Bulk extraction (more efficient - single FFI call)
+        pub fn Geom_BSplineCurve_Poles(handle: &HandleGeomBSplineCurve, out: &mut [f64]);
+        pub fn Geom_BSplineCurve_KnotSequence(handle: &HandleGeomBSplineCurve, out: &mut [f64]);
+        pub fn Geom_BSplineCurve_Weights(handle: &HandleGeomBSplineCurve, out: &mut [f64]);
+
+        // Individual accessors (for flexibility)
+        pub fn Geom_BSplineCurve_Pole(
+            handle: &HandleGeomBSplineCurve,
+            index: i32,
+        ) -> UniquePtr<gp_Pnt>;
+        pub fn Geom_BSplineCurve_Knot(handle: &HandleGeomBSplineCurve, index: i32) -> f64;
+        pub fn Geom_BSplineCurve_Multiplicity(handle: &HandleGeomBSplineCurve, index: i32) -> i32;
+        pub fn Geom_BSplineCurve_Weight(handle: &HandleGeomBSplineCurve, index: i32) -> f64;
         pub fn BRep_Tool_Triangulation(
             face: &TopoDS_Face,
             location: Pin<&mut TopLoc_Location>,

--- a/crates/opencascade/src/primitives/edge.rs
+++ b/crates/opencascade/src/primitives/edge.rs
@@ -5,6 +5,16 @@ use opencascade_sys::ffi;
 
 use super::make_vec;
 
+/// B-spline curve data extracted from an Edge
+#[derive(Debug, Clone)]
+pub struct BSplineData {
+    pub degree: i32,
+    pub poles: Vec<DVec3>,
+    /// Flat knot vector (knots repeated by their multiplicities)
+    pub knots: Vec<f64>,
+    pub weights: Option<Vec<f64>>,
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum EdgeType {
     Line,
@@ -162,6 +172,45 @@ impl Edge {
         let curve = ffi::BRepAdaptor_Curve_ctor(&self.inner);
 
         EdgeType::from(curve.GetType())
+    }
+
+    /// Extract B-spline curve data from this edge.
+    /// Returns None if the edge is not a B-spline or cannot be converted.
+    pub fn bspline_data(&self) -> Option<BSplineData> {
+        let bspline_handle = ffi::Edge_BSplineCurve(&self.inner);
+        if bspline_handle.is_null() {
+            return None;
+        }
+
+        let degree = ffi::Geom_BSplineCurve_Degree(&bspline_handle);
+        let nb_poles = ffi::Geom_BSplineCurve_NbPoles(&bspline_handle);
+        let is_rational = ffi::Geom_BSplineCurve_IsRational(&bspline_handle);
+
+        // Flat knot vector length = nb_poles + degree + 1
+        let nb_knots_flat = (nb_poles + degree + 1) as usize;
+
+        // Bulk extract poles as flat [x,y,z,x,y,z,...] array
+        let mut poles_flat = vec![0.0; nb_poles as usize * 3];
+        ffi::Geom_BSplineCurve_Poles(&bspline_handle, &mut poles_flat);
+
+        // Convert flat array to Vec<DVec3>
+        let poles: Vec<DVec3> =
+            poles_flat.chunks_exact(3).map(|c| dvec3(c[0], c[1], c[2])).collect();
+
+        // Bulk extract flat knot sequence
+        let mut knots = vec![0.0; nb_knots_flat];
+        ffi::Geom_BSplineCurve_KnotSequence(&bspline_handle, &mut knots);
+
+        // Bulk extract weights if rational
+        let weights = if is_rational {
+            let mut w = vec![0.0; nb_poles as usize];
+            ffi::Geom_BSplineCurve_Weights(&bspline_handle, &mut w);
+            Some(w)
+        } else {
+            None
+        };
+
+        Some(BSplineData { degree, poles, knots, weights })
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `Edge::bspline_data()` method to extract degree, control points (poles), flat knot vector, and weights from B-spline curves
- Includes automatic conversion of non-BSpline curves via `GeomConvert`
- Uses bulk extraction functions for efficiency (single FFI call for all poles, knots, or weights instead of per-element calls)