### PR TITLE
Shape inspection

### DIFF
--- a/crates/opencascade-sys/include/b_rep.hxx
+++ b/crates/opencascade-sys/include/b_rep.hxx
@@ -32,6 +32,4 @@ inline std::unique_ptr<Handle_Poly_Triangulation> BRep_Tool_Triangulation(const 
       new opencascade::handle<Poly_Triangulation>(BRep_Tool::Triangulation(face, location)));
 }
 
-inline bool BRep_Tool_IsClosed(const TopoDS_Wire &wire) {
-  return BRep_Tool::IsClosed(wire);
-}
+inline bool BRep_Tool_IsClosed(const TopoDS_Wire &wire) { return BRep_Tool::IsClosed(wire); }

--- a/crates/opencascade-sys/include/b_rep.hxx
+++ b/crates/opencascade-sys/include/b_rep.hxx
@@ -7,6 +7,7 @@
 #include <TopoDS_Edge.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Vertex.hxx>
+#include <TopoDS_Wire.hxx>
 #include <bindings_common.hxx>
 #include <gp_Pnt.hxx>
 
@@ -29,4 +30,8 @@ inline std::unique_ptr<Handle_Poly_Triangulation> BRep_Tool_Triangulation(const 
                                                                           TopLoc_Location &location) {
   return std::unique_ptr<Handle_Poly_Triangulation>(
       new opencascade::handle<Poly_Triangulation>(BRep_Tool::Triangulation(face, location)));
+}
+
+inline bool BRep_Tool_IsClosed(const TopoDS_Wire &wire) {
+  return BRep_Tool::IsClosed(wire);
 }

--- a/crates/opencascade-sys/include/b_rep_adaptor.hxx
+++ b/crates/opencascade-sys/include/b_rep_adaptor.hxx
@@ -1,7 +1,17 @@
 #include <BRepAdaptor_Curve.hxx>
 #include <bindings_common.hxx>
+#include <gp_Circ.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Vec.hxx>
 
 inline std::unique_ptr<gp_Pnt> BRepAdaptor_Curve_value(const BRepAdaptor_Curve &curve, const Standard_Real U) {
   return std::unique_ptr<gp_Pnt>(new gp_Pnt(curve.Value(U)));
+}
+
+inline void BRepAdaptor_Curve_D1(const BRepAdaptor_Curve &curve, const Standard_Real U, gp_Pnt &P, gp_Vec &V1) {
+  curve.D1(U, P, V1);
+}
+
+inline std::unique_ptr<gp_Circ> BRepAdaptor_Curve_Circle(const BRepAdaptor_Curve &curve) {
+  return std::unique_ptr<gp_Circ>(new gp_Circ(curve.Circle()));
 }

--- a/crates/opencascade-sys/include/geom.hxx
+++ b/crates/opencascade-sys/include/geom.hxx
@@ -2,10 +2,14 @@
 #include <Geom_BezierCurve.hxx>
 #include <Geom_BezierSurface.hxx>
 #include <Geom_Circle.hxx>
+#include <Geom_ConicalSurface.hxx>
 #include <Geom_CylindricalSurface.hxx>
 #include <Geom_Plane.hxx>
+#include <Geom_SphericalSurface.hxx>
 #include <Geom_Surface.hxx>
+#include <Geom_ToroidalSurface.hxx>
 #include <Geom_TrimmedCurve.hxx>
+#include <gp_Ax3.hxx>
 #include <gp_Circ.hxx>
 #include <bindings_common.hxx>
 
@@ -54,4 +58,76 @@ new_HandleGeomCircle_from_HandleGeomCurve(const Handle_Geom_Curve &curve) {
 
 inline std::unique_ptr<gp_Circ> HandleGeomCircle_Circ(const Handle_Geom_Circle &circle) {
   return std::unique_ptr<gp_Circ>(new gp_Circ(circle->Circ()));
+}
+
+// CylindricalSurface downcast + accessors
+
+inline std::unique_ptr<Handle_Geom_CylindricalSurface>
+new_HandleGeomCylindricalSurface_from_HandleGeomSurface(const Handle_Geom_Surface &surface) {
+  Handle_Geom_CylindricalSurface handle = opencascade::handle<Geom_CylindricalSurface>::DownCast(surface);
+  return std::unique_ptr<Handle_Geom_CylindricalSurface>(new opencascade::handle<Geom_CylindricalSurface>(handle));
+}
+
+inline double HandleGeomCylindricalSurface_Radius(const Handle_Geom_CylindricalSurface &cyl) {
+  return cyl->Radius();
+}
+
+inline const gp_Ax3 &HandleGeomCylindricalSurface_Position(const Handle_Geom_CylindricalSurface &cyl) {
+  return cyl->Position();
+}
+
+// SphericalSurface downcast + accessors
+
+inline std::unique_ptr<Handle_Geom_SphericalSurface>
+new_HandleGeomSphericalSurface_from_HandleGeomSurface(const Handle_Geom_Surface &surface) {
+  Handle_Geom_SphericalSurface handle = opencascade::handle<Geom_SphericalSurface>::DownCast(surface);
+  return std::unique_ptr<Handle_Geom_SphericalSurface>(new opencascade::handle<Geom_SphericalSurface>(handle));
+}
+
+inline double HandleGeomSphericalSurface_Radius(const Handle_Geom_SphericalSurface &sphere) {
+  return sphere->Radius();
+}
+
+inline const gp_Ax3 &HandleGeomSphericalSurface_Position(const Handle_Geom_SphericalSurface &sphere) {
+  return sphere->Position();
+}
+
+// ConicalSurface downcast + accessors
+
+inline std::unique_ptr<Handle_Geom_ConicalSurface>
+new_HandleGeomConicalSurface_from_HandleGeomSurface(const Handle_Geom_Surface &surface) {
+  Handle_Geom_ConicalSurface handle = opencascade::handle<Geom_ConicalSurface>::DownCast(surface);
+  return std::unique_ptr<Handle_Geom_ConicalSurface>(new opencascade::handle<Geom_ConicalSurface>(handle));
+}
+
+inline double HandleGeomConicalSurface_RefRadius(const Handle_Geom_ConicalSurface &cone) {
+  return cone->RefRadius();
+}
+
+inline double HandleGeomConicalSurface_SemiAngle(const Handle_Geom_ConicalSurface &cone) {
+  return cone->SemiAngle();
+}
+
+inline const gp_Ax3 &HandleGeomConicalSurface_Position(const Handle_Geom_ConicalSurface &cone) {
+  return cone->Position();
+}
+
+// ToroidalSurface downcast + accessors
+
+inline std::unique_ptr<Handle_Geom_ToroidalSurface>
+new_HandleGeomToroidalSurface_from_HandleGeomSurface(const Handle_Geom_Surface &surface) {
+  Handle_Geom_ToroidalSurface handle = opencascade::handle<Geom_ToroidalSurface>::DownCast(surface);
+  return std::unique_ptr<Handle_Geom_ToroidalSurface>(new opencascade::handle<Geom_ToroidalSurface>(handle));
+}
+
+inline double HandleGeomToroidalSurface_MajorRadius(const Handle_Geom_ToroidalSurface &torus) {
+  return torus->MajorRadius();
+}
+
+inline double HandleGeomToroidalSurface_MinorRadius(const Handle_Geom_ToroidalSurface &torus) {
+  return torus->MinorRadius();
+}
+
+inline const gp_Ax3 &HandleGeomToroidalSurface_Position(const Handle_Geom_ToroidalSurface &torus) {
+  return torus->Position();
 }

--- a/crates/opencascade-sys/include/geom.hxx
+++ b/crates/opencascade-sys/include/geom.hxx
@@ -1,10 +1,12 @@
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_BezierCurve.hxx>
 #include <Geom_BezierSurface.hxx>
+#include <Geom_Circle.hxx>
 #include <Geom_CylindricalSurface.hxx>
 #include <Geom_Plane.hxx>
 #include <Geom_Surface.hxx>
 #include <Geom_TrimmedCurve.hxx>
+#include <gp_Circ.hxx>
 #include <bindings_common.hxx>
 
 inline std::unique_ptr<Handle_Geom_CylindricalSurface> Geom_CylindricalSurface_new(const gp_Ax3 &axis, double radius) {
@@ -43,3 +45,13 @@ inline std::unique_ptr<gp_Pnt> HandleGeomCurve_Value(const Handle_Geom_Curve &cu
 }
 
 inline const Handle_Standard_Type &DynamicType(const Handle_Geom_Surface &surface) { return surface->DynamicType(); }
+
+inline std::unique_ptr<Handle_Geom_Circle>
+new_HandleGeomCircle_from_HandleGeomCurve(const Handle_Geom_Curve &curve) {
+  Handle_Geom_Circle circle_handle = opencascade::handle<Geom_Circle>::DownCast(curve);
+  return std::unique_ptr<Handle_Geom_Circle>(new opencascade::handle<Geom_Circle>(circle_handle));
+}
+
+inline std::unique_ptr<gp_Circ> HandleGeomCircle_Circ(const Handle_Geom_Circle &circle) {
+  return std::unique_ptr<gp_Circ>(new gp_Circ(circle->Circ()));
+}

--- a/crates/opencascade-sys/include/geom.hxx
+++ b/crates/opencascade-sys/include/geom.hxx
@@ -9,9 +9,9 @@
 #include <Geom_Surface.hxx>
 #include <Geom_ToroidalSurface.hxx>
 #include <Geom_TrimmedCurve.hxx>
+#include <bindings_common.hxx>
 #include <gp_Ax3.hxx>
 #include <gp_Circ.hxx>
-#include <bindings_common.hxx>
 
 inline std::unique_ptr<Handle_Geom_CylindricalSurface> Geom_CylindricalSurface_new(const gp_Ax3 &axis, double radius) {
   return std::unique_ptr<Handle_Geom_CylindricalSurface>(
@@ -50,8 +50,7 @@ inline std::unique_ptr<gp_Pnt> HandleGeomCurve_Value(const Handle_Geom_Curve &cu
 
 inline const Handle_Standard_Type &DynamicType(const Handle_Geom_Surface &surface) { return surface->DynamicType(); }
 
-inline std::unique_ptr<Handle_Geom_Circle>
-new_HandleGeomCircle_from_HandleGeomCurve(const Handle_Geom_Curve &curve) {
+inline std::unique_ptr<Handle_Geom_Circle> new_HandleGeomCircle_from_HandleGeomCurve(const Handle_Geom_Curve &curve) {
   Handle_Geom_Circle circle_handle = opencascade::handle<Geom_Circle>::DownCast(curve);
   return std::unique_ptr<Handle_Geom_Circle>(new opencascade::handle<Geom_Circle>(circle_handle));
 }
@@ -68,9 +67,7 @@ new_HandleGeomCylindricalSurface_from_HandleGeomSurface(const Handle_Geom_Surfac
   return std::unique_ptr<Handle_Geom_CylindricalSurface>(new opencascade::handle<Geom_CylindricalSurface>(handle));
 }
 
-inline double HandleGeomCylindricalSurface_Radius(const Handle_Geom_CylindricalSurface &cyl) {
-  return cyl->Radius();
-}
+inline double HandleGeomCylindricalSurface_Radius(const Handle_Geom_CylindricalSurface &cyl) { return cyl->Radius(); }
 
 inline const gp_Ax3 &HandleGeomCylindricalSurface_Position(const Handle_Geom_CylindricalSurface &cyl) {
   return cyl->Position();
@@ -84,9 +81,7 @@ new_HandleGeomSphericalSurface_from_HandleGeomSurface(const Handle_Geom_Surface 
   return std::unique_ptr<Handle_Geom_SphericalSurface>(new opencascade::handle<Geom_SphericalSurface>(handle));
 }
 
-inline double HandleGeomSphericalSurface_Radius(const Handle_Geom_SphericalSurface &sphere) {
-  return sphere->Radius();
-}
+inline double HandleGeomSphericalSurface_Radius(const Handle_Geom_SphericalSurface &sphere) { return sphere->Radius(); }
 
 inline const gp_Ax3 &HandleGeomSphericalSurface_Position(const Handle_Geom_SphericalSurface &sphere) {
   return sphere->Position();
@@ -100,13 +95,9 @@ new_HandleGeomConicalSurface_from_HandleGeomSurface(const Handle_Geom_Surface &s
   return std::unique_ptr<Handle_Geom_ConicalSurface>(new opencascade::handle<Geom_ConicalSurface>(handle));
 }
 
-inline double HandleGeomConicalSurface_RefRadius(const Handle_Geom_ConicalSurface &cone) {
-  return cone->RefRadius();
-}
+inline double HandleGeomConicalSurface_RefRadius(const Handle_Geom_ConicalSurface &cone) { return cone->RefRadius(); }
 
-inline double HandleGeomConicalSurface_SemiAngle(const Handle_Geom_ConicalSurface &cone) {
-  return cone->SemiAngle();
-}
+inline double HandleGeomConicalSurface_SemiAngle(const Handle_Geom_ConicalSurface &cone) { return cone->SemiAngle(); }
 
 inline const gp_Ax3 &HandleGeomConicalSurface_Position(const Handle_Geom_ConicalSurface &cone) {
   return cone->Position();

--- a/crates/opencascade-sys/src/b_rep.rs
+++ b/crates/opencascade-sys/src/b_rep.rs
@@ -10,6 +10,7 @@ mod inner {
         type TopoDS_Face = crate::topo_ds::TopoDS_Face;
         type TopoDS_Edge = crate::topo_ds::TopoDS_Edge;
         type TopoDS_Vertex = crate::topo_ds::TopoDS_Vertex;
+        type TopoDS_Wire = crate::topo_ds::TopoDS_Wire;
         type Handle_Geom_Surface = crate::geom::Handle_Geom_Surface;
         type Handle_Geom_Curve = crate::geom::Handle_Geom_Curve;
         type Handle_Poly_Triangulation = crate::poly::Handle_Poly_Triangulation;
@@ -32,5 +33,6 @@ mod inner {
             face: &TopoDS_Face,
             location: Pin<&mut TopLoc_Location>,
         ) -> UniquePtr<Handle_Poly_Triangulation>;
+        pub fn BRep_Tool_IsClosed(wire: &TopoDS_Wire) -> bool;
     }
 }

--- a/crates/opencascade-sys/src/b_rep_adaptor.rs
+++ b/crates/opencascade-sys/src/b_rep_adaptor.rs
@@ -6,6 +6,8 @@ mod inner {
         include!("opencascade-sys/include/b_rep_adaptor.hxx");
 
         type gp_Pnt = crate::gp::gp_Pnt;
+        type gp_Vec = crate::gp::gp_Vec;
+        type gp_Circ = crate::gp::gp_Circ;
         type GeomAbs_CurveType = crate::geom_abs::GeomAbs_CurveType;
         type TopoDS_Edge = crate::topo_ds::TopoDS_Edge;
 
@@ -15,6 +17,13 @@ mod inner {
         pub fn FirstParameter(self: &BRepAdaptor_Curve) -> f64;
         pub fn LastParameter(self: &BRepAdaptor_Curve) -> f64;
         pub fn BRepAdaptor_Curve_value(curve: &BRepAdaptor_Curve, u: f64) -> UniquePtr<gp_Pnt>;
+        pub fn BRepAdaptor_Curve_D1(
+            curve: &BRepAdaptor_Curve,
+            u: f64,
+            point: Pin<&mut gp_Pnt>,
+            vec: Pin<&mut gp_Vec>,
+        );
+        pub fn BRepAdaptor_Curve_Circle(curve: &BRepAdaptor_Curve) -> UniquePtr<gp_Circ>;
         pub fn GetType(self: &BRepAdaptor_Curve) -> GeomAbs_CurveType;
     }
 }

--- a/crates/opencascade-sys/src/geom.rs
+++ b/crates/opencascade-sys/src/geom.rs
@@ -7,6 +7,7 @@ mod inner {
 
         type gp_Ax3 = crate::gp::gp_Ax3;
         type gp_Pnt = crate::gp::gp_Pnt;
+        type gp_Circ = crate::gp::gp_Circ;
         type TColgp_Array2OfPnt = crate::t_col_gp::TColgp_Array2OfPnt;
         type TColgp_HArray1OfPnt = crate::t_col_gp::TColgp_HArray1OfPnt;
         type Handle_Standard_Type = crate::standard::Handle_Standard_Type;
@@ -34,6 +35,9 @@ mod inner {
 
         type Handle_Geom_Plane;
         pub fn IsNull(self: &Handle_Geom_Plane) -> bool;
+
+        type Handle_Geom_Circle;
+        pub fn IsNull(self: &Handle_Geom_Circle) -> bool;
 
         type Handle_Geom_CylindricalSurface;
         pub fn IsNull(self: &Handle_Geom_CylindricalSurface) -> bool;
@@ -74,6 +78,11 @@ mod inner {
             geom_surface_handle: &Handle_Geom_Surface,
         ) -> UniquePtr<Handle_Geom_Plane>;
 
+        pub fn new_HandleGeomCircle_from_HandleGeomCurve(
+            curve: &Handle_Geom_Curve,
+        ) -> UniquePtr<Handle_Geom_Circle>;
+        pub fn HandleGeomCircle_Circ(circle: &Handle_Geom_Circle) -> UniquePtr<gp_Circ>;
+
         #[cxx_name = "construct_unique"]
         pub fn new_HandleGeomCurve_from_HandleGeom_BSplineCurve(
             bspline_curve_handle: &Handle_Geom_BSplineCurve,
@@ -90,6 +99,7 @@ mod inner {
         ) -> UniquePtr<Handle_Geom_Curve>;
     }
 
+    impl UniquePtr<Handle_Geom_Circle> {}
     impl UniquePtr<Handle_Geom_CylindricalSurface> {}
     impl UniquePtr<Handle_Geom_BezierSurface> {}
     impl UniquePtr<Handle_Geom_BezierCurve> {}

--- a/crates/opencascade-sys/src/geom.rs
+++ b/crates/opencascade-sys/src/geom.rs
@@ -36,6 +36,15 @@ mod inner {
         type Handle_Geom_Plane;
         pub fn IsNull(self: &Handle_Geom_Plane) -> bool;
 
+        type Handle_Geom_SphericalSurface;
+        pub fn IsNull(self: &Handle_Geom_SphericalSurface) -> bool;
+
+        type Handle_Geom_ConicalSurface;
+        pub fn IsNull(self: &Handle_Geom_ConicalSurface) -> bool;
+
+        type Handle_Geom_ToroidalSurface;
+        pub fn IsNull(self: &Handle_Geom_ToroidalSurface) -> bool;
+
         type Handle_Geom_Circle;
         pub fn IsNull(self: &Handle_Geom_Circle) -> bool;
 
@@ -78,6 +87,36 @@ mod inner {
             geom_surface_handle: &Handle_Geom_Surface,
         ) -> UniquePtr<Handle_Geom_Plane>;
 
+        pub fn new_HandleGeomCylindricalSurface_from_HandleGeomSurface(
+            geom_surface_handle: &Handle_Geom_Surface,
+        ) -> UniquePtr<Handle_Geom_CylindricalSurface>;
+        pub fn HandleGeomCylindricalSurface_Radius(cyl: &Handle_Geom_CylindricalSurface) -> f64;
+        pub fn HandleGeomCylindricalSurface_Position(
+            cyl: &Handle_Geom_CylindricalSurface,
+        ) -> &gp_Ax3;
+
+        pub fn new_HandleGeomSphericalSurface_from_HandleGeomSurface(
+            geom_surface_handle: &Handle_Geom_Surface,
+        ) -> UniquePtr<Handle_Geom_SphericalSurface>;
+        pub fn HandleGeomSphericalSurface_Radius(sphere: &Handle_Geom_SphericalSurface) -> f64;
+        pub fn HandleGeomSphericalSurface_Position(
+            sphere: &Handle_Geom_SphericalSurface,
+        ) -> &gp_Ax3;
+
+        pub fn new_HandleGeomConicalSurface_from_HandleGeomSurface(
+            geom_surface_handle: &Handle_Geom_Surface,
+        ) -> UniquePtr<Handle_Geom_ConicalSurface>;
+        pub fn HandleGeomConicalSurface_RefRadius(cone: &Handle_Geom_ConicalSurface) -> f64;
+        pub fn HandleGeomConicalSurface_SemiAngle(cone: &Handle_Geom_ConicalSurface) -> f64;
+        pub fn HandleGeomConicalSurface_Position(cone: &Handle_Geom_ConicalSurface) -> &gp_Ax3;
+
+        pub fn new_HandleGeomToroidalSurface_from_HandleGeomSurface(
+            geom_surface_handle: &Handle_Geom_Surface,
+        ) -> UniquePtr<Handle_Geom_ToroidalSurface>;
+        pub fn HandleGeomToroidalSurface_MajorRadius(torus: &Handle_Geom_ToroidalSurface) -> f64;
+        pub fn HandleGeomToroidalSurface_MinorRadius(torus: &Handle_Geom_ToroidalSurface) -> f64;
+        pub fn HandleGeomToroidalSurface_Position(torus: &Handle_Geom_ToroidalSurface) -> &gp_Ax3;
+
         pub fn new_HandleGeomCircle_from_HandleGeomCurve(
             curve: &Handle_Geom_Curve,
         ) -> UniquePtr<Handle_Geom_Circle>;
@@ -101,6 +140,9 @@ mod inner {
 
     impl UniquePtr<Handle_Geom_Circle> {}
     impl UniquePtr<Handle_Geom_CylindricalSurface> {}
+    impl UniquePtr<Handle_Geom_SphericalSurface> {}
+    impl UniquePtr<Handle_Geom_ConicalSurface> {}
+    impl UniquePtr<Handle_Geom_ToroidalSurface> {}
     impl UniquePtr<Handle_Geom_BezierSurface> {}
     impl UniquePtr<Handle_Geom_BezierCurve> {}
     impl UniquePtr<Handle_Geom_Plane> {}

--- a/crates/opencascade-sys/src/gp.rs
+++ b/crates/opencascade-sys/src/gp.rs
@@ -61,6 +61,8 @@ mod inner {
         type gp_Ax3;
         #[cxx_name = "construct_unique"]
         pub fn gp_Ax3_from_gp_Ax2(axis: &gp_Ax2) -> UniquePtr<gp_Ax3>;
+        pub fn Location(self: &gp_Ax3) -> &gp_Pnt;
+        pub fn Direction(self: &gp_Ax3) -> &gp_Dir;
 
         type gp_Dir2d;
         #[cxx_name = "construct_unique"]

--- a/crates/opencascade-sys/src/gp.rs
+++ b/crates/opencascade-sys/src/gp.rs
@@ -45,6 +45,8 @@ mod inner {
         type gp_Circ;
         #[cxx_name = "construct_unique"]
         pub fn gp_Circ_new(axis: &gp_Ax2, radius: f64) -> UniquePtr<gp_Circ>;
+        pub fn Radius(self: &gp_Circ) -> f64;
+        pub fn Position(self: &gp_Circ) -> &gp_Ax2;
 
         type gp_Ax1;
         #[cxx_name = "construct_unique"]
@@ -53,6 +55,8 @@ mod inner {
         type gp_Ax2;
         #[cxx_name = "construct_unique"]
         pub fn gp_Ax2_new(origin: &gp_Pnt, main_dir: &gp_Dir) -> UniquePtr<gp_Ax2>;
+        pub fn Location(self: &gp_Ax2) -> &gp_Pnt;
+        pub fn Direction(self: &gp_Ax2) -> &gp_Dir;
 
         type gp_Ax3;
         #[cxx_name = "construct_unique"]

--- a/crates/opencascade/src/primitives.rs
+++ b/crates/opencascade/src/primitives.rs
@@ -25,6 +25,12 @@ pub use vertex::*;
 pub use wire::*;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+pub enum PositionMode {
+    Parameter,
+    Length,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ShapeType {
     /// Abstract topological data structure describes a basic entity.
     Shape,

--- a/crates/opencascade/src/primitives.rs
+++ b/crates/opencascade/src/primitives.rs
@@ -267,3 +267,36 @@ impl From<JoinType> for ffi::geom_abs::GeomAbs_JoinType {
         }
     }
 }
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum SurfaceType {
+    Plane,
+    Cylinder,
+    Cone,
+    Sphere,
+    Torus,
+    BezierSurface,
+    BSplineSurface,
+    SurfaceOfRevolution,
+    SurfaceOfExtrusion,
+    OffsetSurface,
+    OtherSurface,
+}
+
+impl std::fmt::Display for SurfaceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SurfaceType::Plane => write!(f, "Plane"),
+            SurfaceType::Cylinder => write!(f, "Cylinder"),
+            SurfaceType::Cone => write!(f, "Cone"),
+            SurfaceType::Sphere => write!(f, "Sphere"),
+            SurfaceType::Torus => write!(f, "Torus"),
+            SurfaceType::BezierSurface => write!(f, "BezierSurface"),
+            SurfaceType::BSplineSurface => write!(f, "BSplineSurface"),
+            SurfaceType::SurfaceOfRevolution => write!(f, "SurfaceOfRevolution"),
+            SurfaceType::SurfaceOfExtrusion => write!(f, "SurfaceOfExtrusion"),
+            SurfaceType::OffsetSurface => write!(f, "OffsetSurface"),
+            SurfaceType::OtherSurface => write!(f, "OtherSurface"),
+        }
+    }
+}

--- a/crates/opencascade/src/primitives/edge.rs
+++ b/crates/opencascade/src/primitives/edge.rs
@@ -1,5 +1,5 @@
 use super::make_vec;
-use crate::primitives::{make_axis_2, make_point};
+use crate::primitives::{make_axis_2, make_point, PositionMode};
 use cxx::UniquePtr;
 use glam::{dvec3, DVec3};
 use opencascade_sys as ffi;
@@ -173,6 +173,55 @@ impl Edge {
         let curve = ffi::b_rep_adaptor::BRepAdaptor_Curve_new(&self.inner);
 
         EdgeType::from(curve.GetType())
+    }
+
+    pub fn length(&self) -> f64 {
+        let mut props = ffi::g_prop::GProps_new();
+        ffi::b_rep_g_prop::BRepGProp::LinearProperties(
+            ffi::topo_ds::cast_edge_to_shape(&self.inner),
+            props.pin_mut(),
+            false,
+            false,
+        );
+        props.Mass()
+    }
+
+    pub fn tangent_at(&self, position: f64, mode: PositionMode) -> DVec3 {
+        let curve = ffi::b_rep_adaptor::BRepAdaptor_Curve_new(&self.inner);
+        let param = match mode {
+            PositionMode::Parameter => position,
+            PositionMode::Length => {
+                let first = curve.FirstParameter();
+                let last = curve.LastParameter();
+                first + position * (last - first)
+            },
+        };
+
+        let mut point = ffi::gp::new_point(0.0, 0.0, 0.0);
+        let mut vec = ffi::gp::new_vec(0.0, 0.0, 0.0);
+        ffi::b_rep_adaptor::BRepAdaptor_Curve_D1(&curve, param, point.pin_mut(), vec.pin_mut());
+
+        dvec3(vec.X(), vec.Y(), vec.Z()).normalize()
+    }
+
+    pub fn arc_center(&self) -> Option<DVec3> {
+        let curve = ffi::b_rep_adaptor::BRepAdaptor_Curve_new(&self.inner);
+        if curve.GetType() != ffi::geom_abs::GeomAbs_CurveType::GeomAbs_Circle {
+            return None;
+        }
+        let circ = ffi::b_rep_adaptor::BRepAdaptor_Curve_Circle(&curve);
+        let pos = circ.Position();
+        let loc = pos.Location();
+        Some(dvec3(loc.X(), loc.Y(), loc.Z()))
+    }
+
+    pub fn radius(&self) -> Option<f64> {
+        let curve = ffi::b_rep_adaptor::BRepAdaptor_Curve_new(&self.inner);
+        if curve.GetType() != ffi::geom_abs::GeomAbs_CurveType::GeomAbs_Circle {
+            return None;
+        }
+        let circ = ffi::b_rep_adaptor::BRepAdaptor_Curve_Circle(&curve);
+        Some(circ.Radius())
     }
 }
 

--- a/crates/opencascade/src/primitives/face.rs
+++ b/crates/opencascade/src/primitives/face.rs
@@ -3,7 +3,8 @@ use crate::{
     law_function::law_function_from_graph,
     make_pipe_shell::make_pipe_shell_with_law_function,
     primitives::{
-        make_axis_1, make_point, make_vec, EdgeIterator, JoinType, Shape, Solid, Surface, Wire,
+        make_axis_1, make_point, make_vec, EdgeIterator, JoinType, Shape, Solid, Surface,
+        SurfaceType, Wire,
     },
     workplane::Workplane,
 };
@@ -383,6 +384,30 @@ impl Face {
         props.Mass()
     }
 
+    pub fn surface_type(&self) -> SurfaceType {
+        let surface = ffi::b_rep::BRep_Tool_Surface(&self.inner);
+        let dynamic_type = ffi::geom::DynamicType(&surface);
+        let name = ffi::standard::type_name(dynamic_type);
+
+        match name.as_str() {
+            "Geom_Plane" => SurfaceType::Plane,
+            "Geom_CylindricalSurface" => SurfaceType::Cylinder,
+            "Geom_ConicalSurface" => SurfaceType::Cone,
+            "Geom_SphericalSurface" => SurfaceType::Sphere,
+            "Geom_ToroidalSurface" => SurfaceType::Torus,
+            "Geom_BezierSurface" => SurfaceType::BezierSurface,
+            "Geom_BSplineSurface" => SurfaceType::BSplineSurface,
+            "Geom_SurfaceOfRevolution" => SurfaceType::SurfaceOfRevolution,
+            "Geom_SurfaceOfExtrusion" => SurfaceType::SurfaceOfExtrusion,
+            "Geom_OffsetSurface" => SurfaceType::OffsetSurface,
+            _ => SurfaceType::OtherSurface,
+        }
+    }
+
+    pub fn is_planar(&self) -> bool {
+        self.surface_type() == SurfaceType::Plane
+    }
+
     pub fn orientation(&self) -> FaceOrientation {
         FaceOrientation::from(self.inner.Orientation())
     }
@@ -548,6 +573,7 @@ impl From<ffi::top_abs::TopAbs_Orientation> for FaceOrientation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::primitives::shape::Shape;
 
     #[test]
     fn test_add() {
@@ -557,5 +583,38 @@ mod tests {
             "Expected surface_area() to be ~35.0, was actually {}",
             face.surface_area()
         );
+    }
+
+    #[test]
+    fn test_surface_type_plane() {
+        let face = Workplane::xy().rect(7.0, 5.0).to_face();
+        assert_eq!(face.surface_type(), SurfaceType::Plane);
+    }
+
+    #[test]
+    fn test_surface_type_cylinder() {
+        let shape = Shape::cylinder_radius_height(3.0, 10.0);
+        let has_cylinder = shape.faces().any(|f| f.surface_type() == SurfaceType::Cylinder);
+        assert!(has_cylinder, "Expected at least one cylindrical face");
+    }
+
+    #[test]
+    fn test_surface_type_sphere() {
+        let shape = Shape::sphere(5.0).build();
+        let has_sphere = shape.faces().any(|f| f.surface_type() == SurfaceType::Sphere);
+        assert!(has_sphere, "Expected at least one spherical face");
+    }
+
+    #[test]
+    fn test_is_planar() {
+        let plane_face = Workplane::xy().rect(7.0, 5.0).to_face();
+        assert!(plane_face.is_planar());
+
+        let shape = Shape::cylinder_radius_height(3.0, 10.0);
+        let cylinder_face = shape
+            .faces()
+            .find(|f| f.surface_type() == SurfaceType::Cylinder)
+            .expect("Expected a cylindrical face");
+        assert!(!cylinder_face.is_planar());
     }
 }

--- a/crates/opencascade/src/primitives/face.rs
+++ b/crates/opencascade/src/primitives/face.rs
@@ -384,6 +384,18 @@ impl Face {
         props.Mass()
     }
 
+    pub fn surface_axis(&self) -> Option<(DVec3, DVec3)> {
+        let handle = ffi::b_rep::BRep_Tool_Surface(&self.inner);
+        let surface = Surface { inner: handle };
+        surface.axis()
+    }
+
+    pub fn surface_radius(&self) -> Option<f64> {
+        let handle = ffi::b_rep::BRep_Tool_Surface(&self.inner);
+        let surface = Surface { inner: handle };
+        surface.radius()
+    }
+
     pub fn surface_type(&self) -> SurfaceType {
         let surface = ffi::b_rep::BRep_Tool_Surface(&self.inner);
         let dynamic_type = ffi::geom::DynamicType(&surface);
@@ -616,5 +628,46 @@ mod tests {
             .find(|f| f.surface_type() == SurfaceType::Cylinder)
             .expect("Expected a cylindrical face");
         assert!(!cylinder_face.is_planar());
+    }
+
+    #[test]
+    fn test_cylindrical_face_axis_is_z_direction() {
+        let shape = Shape::cylinder_radius_height(3.0, 10.0);
+        let cylinder_face = shape
+            .faces()
+            .find(|f| f.surface_type() == SurfaceType::Cylinder)
+            .expect("Expected a cylindrical face");
+        let axis = cylinder_face.surface_axis();
+        assert!(axis.is_some(), "Expected Some axis for cylindrical face");
+        let (_origin, direction) = axis.unwrap();
+        assert!(
+            (direction - DVec3::Z).length() < 0.0001 || (direction + DVec3::Z).length() < 0.0001,
+            "Expected Z direction, got {:?}",
+            direction
+        );
+    }
+
+    #[test]
+    fn test_planar_face_axis_returns_none() {
+        let face = Workplane::xy().rect(7.0, 5.0).to_face();
+        assert_eq!(face.surface_axis(), None);
+    }
+
+    #[test]
+    fn test_cylindrical_face_radius() {
+        let shape = Shape::cylinder_radius_height(5.0, 10.0);
+        let cylinder_face = shape
+            .faces()
+            .find(|f| f.surface_type() == SurfaceType::Cylinder)
+            .expect("Expected a cylindrical face");
+        let radius = cylinder_face.surface_radius();
+        assert!(radius.is_some(), "Expected Some radius for cylindrical face");
+        assert!((radius.unwrap() - 5.0).abs() < 0.0001, "Expected radius ~5.0, got {:?}", radius);
+    }
+
+    #[test]
+    fn test_planar_face_radius_returns_none() {
+        let face = Workplane::xy().rect(7.0, 5.0).to_face();
+        assert_eq!(face.surface_radius(), None);
     }
 }

--- a/crates/opencascade/src/primitives/shape.rs
+++ b/crates/opencascade/src/primitives/shape.rs
@@ -832,6 +832,36 @@ impl Shape {
         Self::from_shape(brep.pin_mut().Shape())
     }
 
+    pub fn center_of_mass(&self) -> DVec3 {
+        let mut props = ffi::g_prop::GProps_new();
+
+        match self.shape_type() {
+            ShapeType::Face => ffi::b_rep_g_prop::BRepGProp::SurfaceProperties(
+                &self.inner,
+                props.pin_mut(),
+                false,
+                false,
+            ),
+            ShapeType::Solid => ffi::b_rep_g_prop::BRepGProp::VolumeProperties(
+                &self.inner,
+                props.pin_mut(),
+                true,
+                false,
+                false,
+            ),
+            _ => ffi::b_rep_g_prop::BRepGProp::VolumeProperties(
+                &self.inner,
+                props.pin_mut(),
+                true,
+                false,
+                false,
+            ),
+        }
+
+        let center = ffi::g_prop::GProp_GProps_CentreOfMass(&props);
+        dvec3(center.X(), center.Y(), center.Z())
+    }
+
     /// Create a translated copy of this shape.
     #[must_use]
     pub fn translated(&self, offset: DVec3) -> Self {
@@ -999,6 +1029,32 @@ mod tests {
         assert!(shape.as_solid().is_some());
         assert!(shape.as_wire().is_none());
         assert!(shape.as_face().is_none());
+    }
+
+    #[test]
+    fn test_center_of_mass_face() {
+        let shape = Shape::from(&Face::from_wire(&Wire::rect(7.0, 5.0)));
+        let com = shape.center_of_mass();
+        assert!(
+            com.distance_squared(dvec3(0.0, 0.0, 0.0)) <= 0.00001,
+            "Expected center of mass at (0, 0, 0), got ({}, {}, {})",
+            com.x,
+            com.y,
+            com.z,
+        );
+    }
+
+    #[test]
+    fn test_center_of_mass_solid() {
+        let shape = Shape::box_centered(10.0, 10.0, 10.0);
+        let com = shape.center_of_mass();
+        assert!(
+            com.distance_squared(dvec3(0.0, 0.0, 0.0)) <= 0.00001,
+            "Expected center of mass at (0, 0, 0), got ({}, {}, {})",
+            com.x,
+            com.y,
+            com.z,
+        );
     }
 
     #[test]

--- a/crates/opencascade/src/primitives/solid.rs
+++ b/crates/opencascade/src/primitives/solid.rs
@@ -132,4 +132,99 @@ impl Solid {
         let wire = Wire::from_ordered_points(points)?;
         Ok(Face::from_wire(&wire).extrude(dvec3(0.0, 0.0, h)))
     }
+
+    #[must_use]
+    pub fn volume(&self) -> f64 {
+        let mut props = ffi::g_prop::GProps_new();
+        let inner_shape = ffi::topo_ds::cast_solid_to_shape(&self.inner);
+        ffi::b_rep_g_prop::BRepGProp::VolumeProperties(
+            inner_shape,
+            props.pin_mut(),
+            true,
+            false,
+            false,
+        );
+        props.Mass()
+    }
+
+    #[must_use]
+    pub fn center_of_mass(&self) -> DVec3 {
+        let mut props = ffi::g_prop::GProps_new();
+        let inner_shape = ffi::topo_ds::cast_solid_to_shape(&self.inner);
+        ffi::b_rep_g_prop::BRepGProp::VolumeProperties(
+            inner_shape,
+            props.pin_mut(),
+            true,
+            false,
+            false,
+        );
+        let center = ffi::g_prop::GProp_GProps_CentreOfMass(&props);
+        dvec3(center.X(), center.Y(), center.Z())
+    }
+
+    #[must_use]
+    pub fn surface_area(&self) -> f64 {
+        let mut props = ffi::g_prop::GProps_new();
+        let inner_shape = ffi::topo_ds::cast_solid_to_shape(&self.inner);
+        ffi::b_rep_g_prop::BRepGProp::SurfaceProperties(inner_shape, props.pin_mut(), false, false);
+        props.Mass()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_volume_of_box() {
+        let shape = Shape::box_centered(10.0, 10.0, 10.0);
+        let solid = shape.expect_solid();
+        let volume = solid.volume();
+        assert!((volume - 1000.0).abs() <= 0.00001, "Expected volume ~1000.0, got {volume}",);
+    }
+
+    #[test]
+    fn test_volume_of_cylinder() {
+        let shape = Shape::cylinder_radius_height(3.0, 15.0);
+        let solid = shape.expect_solid();
+        let volume = solid.volume();
+        let expected = std::f64::consts::PI * 9.0 * 15.0;
+        assert!((volume - expected).abs() <= 0.001, "Expected volume ~{expected}, got {volume}",);
+    }
+
+    #[test]
+    fn test_center_of_mass_of_centered_box() {
+        let shape = Shape::box_centered(10.0, 10.0, 10.0);
+        let solid = shape.expect_solid();
+        let com = solid.center_of_mass();
+        assert!(
+            com.distance_squared(dvec3(0.0, 0.0, 0.0)) <= 0.00001,
+            "Expected center of mass at (0, 0, 0), got ({}, {}, {})",
+            com.x,
+            com.y,
+            com.z,
+        );
+    }
+
+    #[test]
+    fn test_center_of_mass_of_translated_box() {
+        let shape = Shape::box_with_dimensions(10.0, 10.0, 10.0).translated(dvec3(5.0, 5.0, 5.0));
+        let solid = shape.expect_solid();
+        let com = solid.center_of_mass();
+        assert!(
+            com.distance_squared(dvec3(10.0, 10.0, 10.0)) <= 0.00001,
+            "Expected center of mass at (10, 10, 10), got ({}, {}, {})",
+            com.x,
+            com.y,
+            com.z,
+        );
+    }
+
+    #[test]
+    fn test_surface_area_of_box() {
+        let shape = Shape::box_centered(10.0, 10.0, 10.0);
+        let solid = shape.expect_solid();
+        let area = solid.surface_area();
+        assert!((area - 600.0).abs() <= 0.00001, "Expected surface area ~600.0, got {area}",);
+    }
 }

--- a/crates/opencascade/src/primitives/surface.rs
+++ b/crates/opencascade/src/primitives/surface.rs
@@ -1,6 +1,6 @@
-use crate::primitives::make_point;
+use crate::primitives::{make_point, SurfaceType};
 use cxx::UniquePtr;
-use glam::DVec3;
+use glam::{dvec3, DVec3};
 use opencascade_sys as ffi;
 
 pub struct Surface {
@@ -30,5 +30,132 @@ impl Surface {
         let inner = ffi::geom::bezier_to_surface(&bezier);
 
         Self { inner }
+    }
+
+    pub fn surface_type(&self) -> SurfaceType {
+        let dynamic_type = ffi::geom::DynamicType(&self.inner);
+        let name = ffi::standard::type_name(dynamic_type);
+
+        match name.as_str() {
+            "Geom_Plane" => SurfaceType::Plane,
+            "Geom_CylindricalSurface" => SurfaceType::Cylinder,
+            "Geom_ConicalSurface" => SurfaceType::Cone,
+            "Geom_SphericalSurface" => SurfaceType::Sphere,
+            "Geom_ToroidalSurface" => SurfaceType::Torus,
+            "Geom_BezierSurface" => SurfaceType::BezierSurface,
+            "Geom_BSplineSurface" => SurfaceType::BSplineSurface,
+            "Geom_SurfaceOfRevolution" => SurfaceType::SurfaceOfRevolution,
+            "Geom_SurfaceOfExtrusion" => SurfaceType::SurfaceOfExtrusion,
+            "Geom_OffsetSurface" => SurfaceType::OffsetSurface,
+            _ => SurfaceType::OtherSurface,
+        }
+    }
+
+    pub fn axis(&self) -> Option<(DVec3, DVec3)> {
+        let surface_type = self.surface_type();
+        match surface_type {
+            SurfaceType::Cylinder => {
+                let cyl =
+                    ffi::geom::new_HandleGeomCylindricalSurface_from_HandleGeomSurface(&self.inner);
+                if cyl.IsNull() {
+                    return None;
+                }
+                let pos = ffi::geom::HandleGeomCylindricalSurface_Position(&cyl);
+                Some((
+                    dvec3(pos.Location().X(), pos.Location().Y(), pos.Location().Z()),
+                    dvec3(pos.Direction().X(), pos.Direction().Y(), pos.Direction().Z()),
+                ))
+            },
+            SurfaceType::Sphere => {
+                let sphere =
+                    ffi::geom::new_HandleGeomSphericalSurface_from_HandleGeomSurface(&self.inner);
+                if sphere.IsNull() {
+                    return None;
+                }
+                let pos = ffi::geom::HandleGeomSphericalSurface_Position(&sphere);
+                Some((
+                    dvec3(pos.Location().X(), pos.Location().Y(), pos.Location().Z()),
+                    dvec3(pos.Direction().X(), pos.Direction().Y(), pos.Direction().Z()),
+                ))
+            },
+            SurfaceType::Cone => {
+                let cone =
+                    ffi::geom::new_HandleGeomConicalSurface_from_HandleGeomSurface(&self.inner);
+                if cone.IsNull() {
+                    return None;
+                }
+                let pos = ffi::geom::HandleGeomConicalSurface_Position(&cone);
+                Some((
+                    dvec3(pos.Location().X(), pos.Location().Y(), pos.Location().Z()),
+                    dvec3(pos.Direction().X(), pos.Direction().Y(), pos.Direction().Z()),
+                ))
+            },
+            SurfaceType::Torus => {
+                let torus =
+                    ffi::geom::new_HandleGeomToroidalSurface_from_HandleGeomSurface(&self.inner);
+                if torus.IsNull() {
+                    return None;
+                }
+                let pos = ffi::geom::HandleGeomToroidalSurface_Position(&torus);
+                Some((
+                    dvec3(pos.Location().X(), pos.Location().Y(), pos.Location().Z()),
+                    dvec3(pos.Direction().X(), pos.Direction().Y(), pos.Direction().Z()),
+                ))
+            },
+            _ => None,
+        }
+    }
+
+    pub fn radius(&self) -> Option<f64> {
+        let surface_type = self.surface_type();
+        match surface_type {
+            SurfaceType::Cylinder => {
+                let cyl =
+                    ffi::geom::new_HandleGeomCylindricalSurface_from_HandleGeomSurface(&self.inner);
+                if cyl.IsNull() {
+                    return None;
+                }
+                Some(ffi::geom::HandleGeomCylindricalSurface_Radius(&cyl))
+            },
+            SurfaceType::Sphere => {
+                let sphere =
+                    ffi::geom::new_HandleGeomSphericalSurface_from_HandleGeomSurface(&self.inner);
+                if sphere.IsNull() {
+                    return None;
+                }
+                Some(ffi::geom::HandleGeomSphericalSurface_Radius(&sphere))
+            },
+            SurfaceType::Cone => {
+                let cone =
+                    ffi::geom::new_HandleGeomConicalSurface_from_HandleGeomSurface(&self.inner);
+                if cone.IsNull() {
+                    return None;
+                }
+                Some(ffi::geom::HandleGeomConicalSurface_RefRadius(&cone))
+            },
+            SurfaceType::Torus => {
+                let torus =
+                    ffi::geom::new_HandleGeomToroidalSurface_from_HandleGeomSurface(&self.inner);
+                if torus.IsNull() {
+                    return None;
+                }
+                Some(ffi::geom::HandleGeomToroidalSurface_MajorRadius(&torus))
+            },
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workplane::Workplane;
+
+    #[test]
+    fn test_surface_type_plane() {
+        let face = Workplane::xy().rect(7.0, 5.0).to_face();
+        let handle = ffi::b_rep::BRep_Tool_Surface(&face.inner);
+        let surface = Surface { inner: handle };
+        assert_eq!(surface.surface_type(), SurfaceType::Plane);
     }
 }

--- a/crates/opencascade/src/primitives/wire.rs
+++ b/crates/opencascade/src/primitives/wire.rs
@@ -263,6 +263,21 @@ impl Wire {
         Face::from_face(make_face.Face())
     }
 
+    pub fn length(&self) -> f64 {
+        let mut props = ffi::g_prop::GProps_new();
+        ffi::b_rep_g_prop::BRepGProp::LinearProperties(
+            ffi::topo_ds::cast_wire_to_shape(&self.inner),
+            props.pin_mut(),
+            false,
+            false,
+        );
+        props.Mass()
+    }
+
+    pub fn is_closed(&self) -> bool {
+        ffi::b_rep::BRep_Tool_IsClosed(&self.inner)
+    }
+
     // Create a closure-based API
     pub fn freeform() {}
 }

--- a/crates/opencascade/tests/edge_inspection.rs
+++ b/crates/opencascade/tests/edge_inspection.rs
@@ -1,0 +1,72 @@
+use glam::DVec3;
+use opencascade::primitives::{Edge, PositionMode};
+
+#[test]
+fn line_segment_length() {
+    let edge = Edge::segment(DVec3::new(0.0, 0.0, 0.0), DVec3::new(3.0, 4.0, 0.0));
+    let length = edge.length();
+    approx_equal(length, 5.0);
+}
+
+#[test]
+fn circle_length() {
+    let edge = Edge::circle(DVec3::new(0.0, 0.0, 0.0), DVec3::Z, 5.0);
+    let length = edge.length();
+    approx_equal(length, std::f64::consts::PI * 10.0);
+}
+
+#[test]
+fn line_tangent_at_midpoint() {
+    let edge = Edge::segment(DVec3::new(0.0, 0.0, 0.0), DVec3::new(10.0, 0.0, 0.0));
+    let tangent = edge.tangent_at(0.5, PositionMode::Parameter);
+    let expected = DVec3::new(1.0, 0.0, 0.0);
+    assert!(tangent.distance_squared(expected) < 1e-6, "expected {expected:?}, got {tangent:?}");
+}
+
+#[test]
+fn circle_tangent_at_start_perpendicular_to_radius() {
+    let edge = Edge::circle(DVec3::new(0.0, 0.0, 0.0), DVec3::Z, 5.0);
+    let tangent = edge.tangent_at(0.0, PositionMode::Parameter);
+    let radius_vec = edge.start_point() - DVec3::new(0.0, 0.0, 0.0);
+    let dot = tangent.dot(radius_vec);
+    assert!(dot.abs() < 1e-6, "tangent {tangent:?} dot radius {radius_vec:?} = {dot}, expected ~0");
+    assert!(tangent.z.abs() < 1e-6, "tangent {tangent:?} should lie in XY plane");
+}
+
+#[test]
+fn arc_center_returns_center_for_circle() {
+    let center = DVec3::new(10.0, 20.0, 30.0);
+    let edge = Edge::circle(center, DVec3::Z, 5.0);
+    let result = edge.arc_center();
+    assert!(result.is_some(), "Expected Some center for circle edge");
+    let result = result.unwrap();
+    assert!(result.distance_squared(center) < 1e-6, "expected {center:?}, got {result:?}");
+}
+
+#[test]
+fn arc_center_returns_none_for_line() {
+    let edge = Edge::segment(DVec3::ZERO, DVec3::X);
+    let result = edge.arc_center();
+    assert!(result.is_none(), "Expected None for line edge, got {result:?}");
+}
+
+#[test]
+fn radius_returns_value_for_circle() {
+    let edge = Edge::circle(DVec3::ZERO, DVec3::Z, 7.0);
+    let result = edge.radius();
+    assert!(result.is_some(), "Expected Some radius for circle edge");
+    approx_equal(result.unwrap(), 7.0);
+}
+
+#[test]
+fn radius_returns_none_for_line() {
+    let edge = Edge::segment(DVec3::ZERO, DVec3::X);
+    let result = edge.radius();
+    assert!(result.is_none(), "Expected None for line edge, got {result:?}");
+}
+
+fn approx_equal(a: f64, b: f64) {
+    let diff = (a - b).abs();
+    let rel = diff / b.abs().max(1e-12);
+    assert!(rel < 1e-4 || diff < 1e-6, "expected {b}, got {a} (diff={diff}, rel={rel})");
+}

--- a/crates/opencascade/tests/wire_inspection.rs
+++ b/crates/opencascade/tests/wire_inspection.rs
@@ -1,0 +1,28 @@
+use glam::DVec3;
+use opencascade::primitives::{Edge, Wire};
+
+#[test]
+fn rectangle_length() {
+    let wire = Wire::rect(7.0, 5.0);
+    let length = wire.length();
+    approx_equal(length, 24.0);
+}
+
+#[test]
+fn closed_wire_returns_true() {
+    let wire = Wire::rect(10.0, 10.0);
+    assert!(wire.is_closed());
+}
+
+#[test]
+fn open_wire_returns_false() {
+    let edge = Edge::segment(DVec3::ZERO, DVec3::new(10.0, 0.0, 0.0));
+    let wire = Wire::from_edges([&edge]);
+    assert!(!wire.is_closed());
+}
+
+fn approx_equal(a: f64, b: f64) {
+    let diff = (a - b).abs();
+    let rel = diff / b.abs().max(1e-12);
+    assert!(rel < 1e-4 || diff < 1e-6, "expected {b}, got {a} (diff={diff}, rel={rel})");
+}


### PR DESCRIPTION
This PR adds inspection/query capabilities across shape types.
I included all the different types in one PR since they are all about inspection of properties but I can split them based on shape type if that is preferable.

The following can be inspected:

#### Solid
- volume(), center_of_mass(), surface_area()

#### Face / Surface
- SurfaceType enum with face type detection
- Surface geometry: periodicity, continuity, degrees, knots, poles, evaluation (d0, d1, d2)

#### Edge
- length(), tangent_at(), arc_center(), radius()

#### Wire
- length(), is_closed()

#### Shape
- center_of_mass()